### PR TITLE
feat: log downstream result support

### DIFF
--- a/common/consume/consume.go
+++ b/common/consume/consume.go
@@ -31,11 +31,8 @@ func AsyncConsume(
 	ip string,
 	retryTimes int,
 	requestDetail *model.RequestDetail,
+	downstreamResult bool,
 ) {
-	if meta.IsChannelTest {
-		return
-	}
-
 	consumeWaitGroup.Add(1)
 	defer func() {
 		consumeWaitGroup.Done()
@@ -56,6 +53,7 @@ func AsyncConsume(
 		ip,
 		retryTimes,
 		requestDetail,
+		downstreamResult,
 	)
 }
 
@@ -71,16 +69,13 @@ func Consume(
 	ip string,
 	retryTimes int,
 	requestDetail *model.RequestDetail,
+	downstreamResult bool,
 ) {
-	if meta.IsChannelTest {
-		return
-	}
-
 	amount := CalculateAmount(usage, inputPrice, outputPrice)
 
 	amount = consumeAmount(ctx, amount, postGroupConsumer, meta)
 
-	err := recordConsume(meta, code, usage, inputPrice, outputPrice, content, ip, requestDetail, amount, retryTimes)
+	err := recordConsume(meta, code, usage, inputPrice, outputPrice, content, ip, requestDetail, amount, retryTimes, downstreamResult)
 	if err != nil {
 		log.Error("error batch record consume: " + err.Error())
 		notify.ErrorThrottle("recordConsume", time.Minute, "record consume failed", err.Error())
@@ -162,6 +157,7 @@ func recordConsume(
 	requestDetail *model.RequestDetail,
 	amount float64,
 	retryTimes int,
+	downstreamResult bool,
 ) error {
 	promptTokens := 0
 	completionTokens := 0
@@ -195,5 +191,6 @@ func recordConsume(
 		ip,
 		retryTimes,
 		requestDetail,
+		downstreamResult,
 	)
 }

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -92,8 +92,8 @@ func testSingleModel(mc *model.ModelCaches, channel *model.Channel, modelName st
 	if !ok {
 		return nil, fmt.Errorf("relay mode %d not implemented", mode)
 	}
-	bizErr := relayController(meta, newc)
-	success := bizErr == nil
+	result := relayController(meta, newc)
+	success := result.Error == nil
 	var respStr string
 	var code int
 	if success {
@@ -106,8 +106,8 @@ func testSingleModel(mc *model.ModelCaches, channel *model.Channel, modelName st
 		}
 		code = w.Code
 	} else {
-		respStr = bizErr.Error.JSONOrEmpty()
-		code = bizErr.StatusCode
+		respStr = result.Error.JSONOrEmpty()
+		code = result.Error.StatusCode
 	}
 
 	return channel.UpdateModelTest(

--- a/model/log.go
+++ b/model/log.go
@@ -63,6 +63,7 @@ type Log struct {
 	Mode                 int            `json:"mode,omitempty"`
 	IP                   string         `gorm:"index"                                                          json:"ip,omitempty"`
 	RetryTimes           int            `json:"retry_times,omitempty"`
+	DownstreamResult     bool           `json:"downstream_result,omitempty"`
 }
 
 func CreateLogIndexes(db *gorm.DB) error {
@@ -103,36 +104,36 @@ func CreateLogIndexes(db *gorm.DB) error {
 	} else {
 		indexes = []string{
 			// used by global search logs
-			"CREATE INDEX IF NOT EXISTS idx_model_reqat ON logs (model, request_at) INCLUDE (code, used_amount, total_tokens, request_id)",
+			"CREATE INDEX IF NOT EXISTS idx_model_reqat ON logs (model, request_at) INCLUDE (code, used_amount, total_tokens, request_id, downstream_result)",
 			// used by global search logs
-			"CREATE INDEX IF NOT EXISTS idx_channel_reqat ON logs (channel_id, request_at) INCLUDE (code, used_amount, total_tokens, request_id)",
+			"CREATE INDEX IF NOT EXISTS idx_channel_reqat ON logs (channel_id, request_at) INCLUDE (code, used_amount, total_tokens, request_id, downstream_result)",
 			// used by global search logs
-			"CREATE INDEX IF NOT EXISTS idx_channel_model_reqat ON logs (channel_id, model, request_at) INCLUDE (code, used_amount, total_tokens, request_id)",
+			"CREATE INDEX IF NOT EXISTS idx_channel_model_reqat ON logs (channel_id, model, request_at) INCLUDE (code, used_amount, total_tokens, request_id, downstream_result)",
 
 			// global day indexes, used by global dashboard
-			"CREATE INDEX IF NOT EXISTS idx_model_reqat_truncday ON logs (model, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens)",
+			"CREATE INDEX IF NOT EXISTS idx_model_reqat_truncday ON logs (model, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens, downstream_result)",
 			// global hour indexes, used by global dashboard
-			"CREATE INDEX IF NOT EXISTS idx_model_reqat_trunchour ON logs (model, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens)",
+			"CREATE INDEX IF NOT EXISTS idx_model_reqat_trunchour ON logs (model, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens, downstream_result)",
 
 			// used by search group logs
-			"CREATE INDEX IF NOT EXISTS idx_group_token_reqat ON logs (group_id, token_name, request_at) INCLUDE (code, used_amount, total_tokens, request_id)",
+			"CREATE INDEX IF NOT EXISTS idx_group_token_reqat ON logs (group_id, token_name, request_at) INCLUDE (code, used_amount, total_tokens, request_id, downstream_result)",
 			// used by search group logs
-			"CREATE INDEX IF NOT EXISTS idx_group_token_reqat ON logs (group_id, token_name, request_at) INCLUDE (code, used_amount, total_tokens, request_id)",
+			"CREATE INDEX IF NOT EXISTS idx_group_token_reqat ON logs (group_id, token_name, request_at) INCLUDE (code, used_amount, total_tokens, request_id, downstream_result)",
 			// used by search group logs
-			"CREATE INDEX IF NOT EXISTS idx_group_model_reqat ON logs (group_id, model, request_at) INCLUDE (code, used_amount, total_tokens, request_id)",
+			"CREATE INDEX IF NOT EXISTS idx_group_model_reqat ON logs (group_id, model, request_at) INCLUDE (code, used_amount, total_tokens, request_id, downstream_result)",
 			// used by search group logs
-			"CREATE INDEX IF NOT EXISTS idx_group_token_model_reqat ON logs (group_id, token_name, model, request_at) INCLUDE (code, used_amount, total_tokens, request_id)",
+			"CREATE INDEX IF NOT EXISTS idx_group_token_model_reqat ON logs (group_id, token_name, model, request_at) INCLUDE (code, used_amount, total_tokens, request_id, downstream_result)",
 
 			// day indexes, used by dashboard
-			"CREATE INDEX IF NOT EXISTS idx_group_reqat_truncday ON logs (group_id, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens)",
-			"CREATE INDEX IF NOT EXISTS idx_group_model_reqat_truncday ON logs (group_id, model, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens)",
-			"CREATE INDEX IF NOT EXISTS idx_group_token_reqat_truncday ON logs (group_id, token_name, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens)",
-			"CREATE INDEX IF NOT EXISTS idx_group_model_token_reqat_truncday ON logs (group_id, model, token_name, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens)",
+			"CREATE INDEX IF NOT EXISTS idx_group_reqat_truncday ON logs (group_id, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens, downstream_result)",
+			"CREATE INDEX IF NOT EXISTS idx_group_model_reqat_truncday ON logs (group_id, model, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens, downstream_result)",
+			"CREATE INDEX IF NOT EXISTS idx_group_token_reqat_truncday ON logs (group_id, token_name, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens, downstream_result)",
+			"CREATE INDEX IF NOT EXISTS idx_group_model_token_reqat_truncday ON logs (group_id, model, token_name, request_at, timestamp_trunc_by_day) INCLUDE (code, used_amount, total_tokens, downstream_result)",
 			// hour indexes, used by dashboard
-			"CREATE INDEX IF NOT EXISTS idx_group_reqat_trunchour ON logs (group_id, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens)",
-			"CREATE INDEX IF NOT EXISTS idx_group_model_reqat_trunchour ON logs (group_id, model, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens)",
-			"CREATE INDEX IF NOT EXISTS idx_group_token_reqat_trunchour ON logs (group_id, token_name, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens)",
-			"CREATE INDEX IF NOT EXISTS idx_group_model_token_reqat_trunchour ON logs (group_id, model, token_name, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens)",
+			"CREATE INDEX IF NOT EXISTS idx_group_reqat_trunchour ON logs (group_id, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens, downstream_result)",
+			"CREATE INDEX IF NOT EXISTS idx_group_model_reqat_trunchour ON logs (group_id, model, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens, downstream_result)",
+			"CREATE INDEX IF NOT EXISTS idx_group_token_reqat_trunchour ON logs (group_id, token_name, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens, downstream_result)",
+			"CREATE INDEX IF NOT EXISTS idx_group_model_token_reqat_trunchour ON logs (group_id, model, token_name, request_at, timestamp_trunc_by_hour) INCLUDE (code, used_amount, total_tokens, downstream_result)",
 		}
 	}
 
@@ -270,6 +271,7 @@ func RecordConsumeLog(
 	ip string,
 	retryTimes int,
 	requestDetail *RequestDetail,
+	downstreamResult bool,
 ) error {
 	log := &Log{
 		RequestID:        requestID,
@@ -293,6 +295,7 @@ func RecordConsumeLog(
 		Content:          content,
 		RetryTimes:       retryTimes,
 		RequestDetail:    requestDetail,
+		DownstreamResult: downstreamResult,
 	}
 	return LogDB.Create(log).Error
 }

--- a/model/utils.go
+++ b/model/utils.go
@@ -173,6 +173,7 @@ func BatchRecordConsume(
 	ip string,
 	retryTimes int,
 	requestDetail *RequestDetail,
+	downstreamResult bool,
 ) error {
 	err := RecordConsumeLog(
 		requestID,
@@ -194,7 +195,12 @@ func BatchRecordConsume(
 		ip,
 		retryTimes,
 		requestDetail,
+		downstreamResult,
 	)
+
+	if !downstreamResult {
+		return err
+	}
 
 	amountDecimal := decimal.NewFromFloat(amount)
 

--- a/relay/adaptor/anthropic/main.go
+++ b/relay/adaptor/anthropic/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/labring/aiproxy/common/render"
 	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
-	"github.com/labring/aiproxy/relay/constant"
 	"github.com/labring/aiproxy/relay/meta"
 	"github.com/labring/aiproxy/relay/model"
 )
@@ -33,7 +32,7 @@ func stopReasonClaude2OpenAI(reason *string) string {
 	}
 	switch *reason {
 	case "end_turn", "stop_sequence":
-		return constant.StopFinishReason
+		return model.StopFinishReason
 	case "max_tokens":
 		return "length"
 	case toolUseType:

--- a/relay/adaptor/aws/llama3/main.go
+++ b/relay/adaptor/aws/llama3/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/labring/aiproxy/model"
 	"github.com/labring/aiproxy/relay/adaptor/aws/utils"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
-	"github.com/labring/aiproxy/relay/constant"
 	"github.com/labring/aiproxy/relay/meta"
 	relaymodel "github.com/labring/aiproxy/relay/model"
 	"github.com/labring/aiproxy/relay/relaymode"
@@ -223,7 +222,7 @@ func StreamHandler(meta *meta.Meta, c *gin.Context) (*relaymodel.ErrorWithStatus
 			if llamaResp.PromptTokenCount > 0 {
 				usage.PromptTokens = llamaResp.PromptTokenCount
 			}
-			if llamaResp.StopReason == constant.StopFinishReason {
+			if llamaResp.StopReason == relaymodel.StopFinishReason {
 				usage.CompletionTokens = llamaResp.GenerationTokenCount
 				usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 			}

--- a/relay/adaptor/baidu/main.go
+++ b/relay/adaptor/baidu/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/labring/aiproxy/common/render"
 	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
-	"github.com/labring/aiproxy/relay/constant"
 	"github.com/labring/aiproxy/relay/meta"
 	"github.com/labring/aiproxy/relay/model"
 	"github.com/labring/aiproxy/relay/utils"
@@ -91,7 +90,7 @@ func responseBaidu2OpenAI(response *ChatResponse) *openai.TextResponse {
 			Role:    "assistant",
 			Content: response.Result,
 		},
-		FinishReason: constant.StopFinishReason,
+		FinishReason: model.StopFinishReason,
 	}
 	fullTextResponse := openai.TextResponse{
 		ID:      response.ID,
@@ -109,7 +108,8 @@ func streamResponseBaidu2OpenAI(meta *meta.Meta, baiduResponse *ChatStreamRespon
 	var choice openai.ChatCompletionsStreamResponseChoice
 	choice.Delta.Content = baiduResponse.Result
 	if baiduResponse.IsEnd {
-		choice.FinishReason = &constant.StopFinishReason
+		finishReason := model.StopFinishReason
+		choice.FinishReason = &finishReason
 	}
 	response := openai.ChatCompletionsStreamResponse{
 		ID:      baiduResponse.ID,

--- a/relay/adaptor/cohere/main.go
+++ b/relay/adaptor/cohere/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/labring/aiproxy/common/render"
 	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
-	"github.com/labring/aiproxy/relay/constant"
 	"github.com/labring/aiproxy/relay/model"
 )
 
@@ -26,7 +25,7 @@ func stopReasonCohere2OpenAI(reason *string) string {
 	}
 	switch *reason {
 	case "COMPLETE":
-		return constant.StopFinishReason
+		return model.StopFinishReason
 	default:
 		return *reason
 	}

--- a/relay/adaptor/coze/main.go
+++ b/relay/adaptor/coze/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/relay/adaptor/coze/constant/messagetype"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
-	"github.com/labring/aiproxy/relay/constant"
 	"github.com/labring/aiproxy/relay/meta"
 	"github.com/labring/aiproxy/relay/model"
 )
@@ -74,7 +73,7 @@ func ResponseCoze2OpenAI(cozeResponse *Response) *openai.TextResponse {
 			Content: responseText,
 			Name:    nil,
 		},
-		FinishReason: constant.StopFinishReason,
+		FinishReason: model.StopFinishReason,
 	}
 	fullTextResponse := openai.TextResponse{
 		ID:      "chatcmpl-" + cozeResponse.ConversationID,

--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/labring/aiproxy/common/render"
 	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
-	"github.com/labring/aiproxy/relay/constant"
 	"github.com/labring/aiproxy/relay/meta"
 	"github.com/labring/aiproxy/relay/model"
 	"github.com/labring/aiproxy/relay/utils"
@@ -361,7 +360,7 @@ func responseGeminiChat2OpenAI(meta *meta.Meta, response *ChatResponse) *openai.
 			Message: model.Message{
 				Role: "assistant",
 			},
-			FinishReason: constant.StopFinishReason,
+			FinishReason: model.StopFinishReason,
 		}
 		if len(candidate.Content.Parts) > 0 {
 			toolCallIndex := -1

--- a/relay/adaptor/ollama/main.go
+++ b/relay/adaptor/ollama/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
 	"github.com/labring/aiproxy/relay/meta"
-	"github.com/labring/aiproxy/relay/model"
 	relaymodel "github.com/labring/aiproxy/relay/model"
 	"github.com/labring/aiproxy/relay/utils"
 )
@@ -82,7 +81,7 @@ func responseOllama2OpenAI(meta *meta.Meta, response *ChatResponse) *openai.Text
 		},
 	}
 	if response.Done {
-		choice.FinishReason = model.StopFinishReason
+		choice.FinishReason = relaymodel.StopFinishReason
 	}
 	fullTextResponse := openai.TextResponse{
 		ID:      "chatcmpl-" + random.GetUUID(),
@@ -104,7 +103,7 @@ func streamResponseOllama2OpenAI(meta *meta.Meta, ollamaResponse *ChatResponse) 
 	choice.Delta.Role = ollamaResponse.Message.Role
 	choice.Delta.Content = ollamaResponse.Message.Content
 	if ollamaResponse.Done {
-		finishReason := model.StopFinishReason
+		finishReason := relaymodel.StopFinishReason
 		choice.FinishReason = &finishReason
 	}
 	response := openai.ChatCompletionsStreamResponse{

--- a/relay/adaptor/ollama/main.go
+++ b/relay/adaptor/ollama/main.go
@@ -16,8 +16,8 @@ import (
 	"github.com/labring/aiproxy/common/splitter"
 	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
-	"github.com/labring/aiproxy/relay/constant"
 	"github.com/labring/aiproxy/relay/meta"
+	"github.com/labring/aiproxy/relay/model"
 	relaymodel "github.com/labring/aiproxy/relay/model"
 	"github.com/labring/aiproxy/relay/utils"
 )
@@ -82,7 +82,7 @@ func responseOllama2OpenAI(meta *meta.Meta, response *ChatResponse) *openai.Text
 		},
 	}
 	if response.Done {
-		choice.FinishReason = constant.StopFinishReason
+		choice.FinishReason = model.StopFinishReason
 	}
 	fullTextResponse := openai.TextResponse{
 		ID:      "chatcmpl-" + random.GetUUID(),
@@ -104,7 +104,8 @@ func streamResponseOllama2OpenAI(meta *meta.Meta, ollamaResponse *ChatResponse) 
 	choice.Delta.Role = ollamaResponse.Message.Role
 	choice.Delta.Content = ollamaResponse.Message.Content
 	if ollamaResponse.Done {
-		choice.FinishReason = &constant.StopFinishReason
+		finishReason := model.StopFinishReason
+		choice.FinishReason = &finishReason
 	}
 	response := openai.ChatCompletionsStreamResponse{
 		ID:      "chatcmpl-" + random.GetUUID(),

--- a/relay/constant/common.go
+++ b/relay/constant/common.go
@@ -1,7 +1,0 @@
-package constant
-
-var (
-	StopFinishReason = "stop"
-	StreamObject     = "chat.completion.chunk"
-	NonStreamObject  = "chat.completion"
-)

--- a/relay/constant/finishreason/define.go
+++ b/relay/constant/finishreason/define.go
@@ -1,5 +1,0 @@
-package finishreason
-
-const (
-	Stop = "stop"
-)

--- a/relay/constant/role/define.go
+++ b/relay/constant/role/define.go
@@ -1,5 +1,0 @@
-package role
-
-const (
-	Assistant = "assistant"
-)

--- a/relay/controller/consume.go
+++ b/relay/controller/consume.go
@@ -1,11 +1,7 @@
 package controller
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/labring/aiproxy/common/balance"
-	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/model"
-	"github.com/labring/aiproxy/relay/meta"
 	"github.com/shopspring/decimal"
 )
 
@@ -31,24 +27,6 @@ func getPreConsumedAmount(req *PreCheckGroupBalanceReq) float64 {
 		InexactFloat64()
 }
 
-func checkGroupBalance(req *PreCheckGroupBalanceReq, meta *meta.Meta, groupRemainBalance float64) bool {
-	if meta.IsChannelTest {
-		return true
-	}
-
-	preConsumedAmount := getPreConsumedAmount(req)
-
-	return groupRemainBalance > preConsumedAmount
-}
-
-func getGroupBalance(ctx *gin.Context, meta *meta.Meta) (float64, balance.PostGroupConsumer, error) {
-	if meta.IsChannelTest {
-		return 0, nil, nil
-	}
-
-	gbc, err := middleware.GetGroupBalanceConsumer(ctx, meta.Group)
-	if err != nil {
-		return 0, nil, err
-	}
-	return gbc.GroupBalance, gbc.Consumer, nil
+func checkGroupBalance(req *PreCheckGroupBalanceReq, groupRemainBalance float64) bool {
+	return groupRemainBalance >= getPreConsumedAmount(req)
 }

--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -45,7 +45,7 @@ func getImageRequest(meta *meta.Meta, c *gin.Context) (*relaymodel.ImageRequest,
 	return imageRequest, nil
 }
 
-func RelayImageHelper(meta *meta.Meta, c *gin.Context) *relaymodel.ErrorWithStatusCode {
+func RelayImageHelper(meta *meta.Meta, c *gin.Context) *HandleResult {
 	return Handle(meta, c, func() (*PreCheckGroupBalanceReq, error) {
 		if !config.GetBillingEnabled() {
 			return &PreCheckGroupBalanceReq{}, nil

--- a/relay/controller/pdf.go
+++ b/relay/controller/pdf.go
@@ -3,10 +3,9 @@ package controller
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/labring/aiproxy/relay/meta"
-	relaymodel "github.com/labring/aiproxy/relay/model"
 )
 
-func RelayParsePdfHelper(meta *meta.Meta, c *gin.Context) *relaymodel.ErrorWithStatusCode {
+func RelayParsePdfHelper(meta *meta.Meta, c *gin.Context) *HandleResult {
 	return Handle(meta, c, func() (*PreCheckGroupBalanceReq, error) {
 		return &PreCheckGroupBalanceReq{}, nil
 	})

--- a/relay/controller/rerank.go
+++ b/relay/controller/rerank.go
@@ -12,7 +12,7 @@ import (
 	"github.com/labring/aiproxy/relay/utils"
 )
 
-func RerankHelper(meta *meta.Meta, c *gin.Context) *relaymodel.ErrorWithStatusCode {
+func RerankHelper(meta *meta.Meta, c *gin.Context) *HandleResult {
 	return Handle(meta, c, func() (*PreCheckGroupBalanceReq, error) {
 		if !config.GetBillingEnabled() {
 			return &PreCheckGroupBalanceReq{}, nil

--- a/relay/controller/stt.go
+++ b/relay/controller/stt.go
@@ -12,10 +12,9 @@ import (
 	"github.com/labring/aiproxy/common/config"
 	"github.com/labring/aiproxy/middleware"
 	"github.com/labring/aiproxy/relay/meta"
-	relaymodel "github.com/labring/aiproxy/relay/model"
 )
 
-func RelaySTTHelper(meta *meta.Meta, c *gin.Context) *relaymodel.ErrorWithStatusCode {
+func RelaySTTHelper(meta *meta.Meta, c *gin.Context) *HandleResult {
 	return Handle(meta, c, func() (*PreCheckGroupBalanceReq, error) {
 		if !config.GetBillingEnabled() {
 			return &PreCheckGroupBalanceReq{}, nil

--- a/relay/controller/text.go
+++ b/relay/controller/text.go
@@ -7,11 +7,10 @@ import (
 	"github.com/labring/aiproxy/common/config"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
 	"github.com/labring/aiproxy/relay/meta"
-	relaymodel "github.com/labring/aiproxy/relay/model"
 	"github.com/labring/aiproxy/relay/utils"
 )
 
-func RelayTextHelper(meta *meta.Meta, c *gin.Context) *relaymodel.ErrorWithStatusCode {
+func RelayTextHelper(meta *meta.Meta, c *gin.Context) *HandleResult {
 	return Handle(meta, c, func() (*PreCheckGroupBalanceReq, error) {
 		if !config.GetBillingEnabled() {
 			return &PreCheckGroupBalanceReq{}, nil

--- a/relay/controller/tts.go
+++ b/relay/controller/tts.go
@@ -7,11 +7,10 @@ import (
 	"github.com/labring/aiproxy/common/config"
 	"github.com/labring/aiproxy/relay/adaptor/openai"
 	"github.com/labring/aiproxy/relay/meta"
-	relaymodel "github.com/labring/aiproxy/relay/model"
 	"github.com/labring/aiproxy/relay/utils"
 )
 
-func RelayTTSHelper(meta *meta.Meta, c *gin.Context) *relaymodel.ErrorWithStatusCode {
+func RelayTTSHelper(meta *meta.Meta, c *gin.Context) *HandleResult {
 	return Handle(meta, c, func() (*PreCheckGroupBalanceReq, error) {
 		if !config.GetBillingEnabled() {
 			return &PreCheckGroupBalanceReq{}, nil

--- a/relay/meta/meta.go
+++ b/relay/meta/meta.go
@@ -32,7 +32,7 @@ type Meta struct {
 	Mode          relaymode.Mode
 	InputTokens   int
 	IsChannelTest bool
-	RetryTimes    int
+	GroupBalance  float64
 }
 
 type Option func(meta *Meta)
@@ -73,9 +73,9 @@ func WithToken(token *model.TokenCache) Option {
 	}
 }
 
-func WithRetryTimes(retryTimes int) Option {
+func WithGroupBalance(groupBalance float64) Option {
 	return func(meta *Meta) {
-		meta.RetryTimes = retryTimes
+		meta.GroupBalance = groupBalance
 	}
 }
 

--- a/relay/model/constant.go
+++ b/relay/model/constant.go
@@ -5,3 +5,9 @@ const (
 	ContentTypeImageURL   = "image_url"
 	ContentTypeInputAudio = "input_audio"
 )
+
+const (
+	StopFinishReason = "stop"
+	StreamObject     = "chat.completion.chunk"
+	NonStreamObject  = "chat.completion"
+)


### PR DESCRIPTION
Record whether it is the final downstream response result, distinguish the intermediate result of retry from the final result.
The intermediate results of retry will not increase the user's request count.
Subsequently, data panels and logs will filter out intermediate results, displaying only the final result.