### PR TITLE
fix: claude raw endpoint sse

### DIFF
--- a/core/relay/adaptor/anthropic/event.go
+++ b/core/relay/adaptor/anthropic/event.go
@@ -1,0 +1,67 @@
+package anthropic
+
+import (
+	"net/http"
+
+	"github.com/bytedance/sonic"
+	"github.com/labring/aiproxy/core/common/conv"
+)
+
+type Anthropic struct {
+	Event string
+	Data  []byte
+}
+
+const (
+	n     = "\n"
+	nn    = "\n\n"
+	event = "event: "
+	data  = "data: "
+)
+
+var (
+	nBytes     = conv.StringToBytes(n)
+	nnBytes    = conv.StringToBytes(nn)
+	eventBytes = conv.StringToBytes(event)
+	dataBytes  = conv.StringToBytes(data)
+)
+
+func (r *Anthropic) Render(w http.ResponseWriter) error {
+	r.WriteContentType(w)
+
+	event := r.Event
+
+	if event == "" {
+		eventNode, err := sonic.Get(r.Data, "type")
+		if err != nil {
+			return err
+		}
+		event, err = eventNode.String()
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, bytes := range [][]byte{
+		eventBytes,
+		conv.StringToBytes(event),
+		nBytes,
+		dataBytes,
+		r.Data,
+		nnBytes,
+	} {
+		// nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+		if _, err := w.Write(bytes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Anthropic) WriteContentType(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.Header().Set("X-Accel-Buffering", "no")
+}

--- a/core/relay/adaptor/anthropic/main.go
+++ b/core/relay/adaptor/anthropic/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/labring/aiproxy/core/common"
 	"github.com/labring/aiproxy/core/common/conv"
 	"github.com/labring/aiproxy/core/common/image"
-	"github.com/labring/aiproxy/core/common/render"
 	"github.com/labring/aiproxy/core/middleware"
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/relay/adaptor/openai"
@@ -136,10 +135,6 @@ func StreamHandler(m *meta.Meta, c *gin.Context, resp *http.Response) (*model.Us
 		}
 		data = data[6:]
 
-		if conv.BytesToString(data) == "[DONE]" {
-			break
-		}
-
 		response, err := StreamResponse2OpenAI(m, data)
 		if err != nil {
 			if writed {
@@ -170,7 +165,7 @@ func StreamHandler(m *meta.Meta, c *gin.Context, resp *http.Response) (*model.Us
 			}
 		}
 
-		render.StringData(c, conv.BytesToString(data))
+		Data(c, data)
 		writed = true
 	}
 
@@ -185,8 +180,6 @@ func StreamHandler(m *meta.Meta, c *gin.Context, resp *http.Response) (*model.Us
 			TotalTokens:      m.InputTokens + openai.CountTokenText(responseText.String(), m.OriginModel),
 		}
 	}
-
-	render.Done(c)
 
 	return usage.ToModelUsage(), nil
 }

--- a/core/relay/adaptor/anthropic/render.go
+++ b/core/relay/adaptor/anthropic/render.go
@@ -1,0 +1,36 @@
+package anthropic
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bytedance/sonic"
+	"github.com/gin-gonic/gin"
+)
+
+func Data(c *gin.Context, data []byte) {
+	if len(c.Errors) > 0 {
+		return
+	}
+	if c.IsAborted() {
+		return
+	}
+	c.Render(-1, &Anthropic{Data: data})
+	c.Writer.Flush()
+}
+
+func ObjectData(c *gin.Context, event string, object any) error {
+	if len(c.Errors) > 0 {
+		return c.Errors.Last()
+	}
+	if c.IsAborted() {
+		return errors.New("context aborted")
+	}
+	jsonData, err := sonic.Marshal(object)
+	if err != nil {
+		return fmt.Errorf("error marshalling object: %w", err)
+	}
+	c.Render(-1, &Anthropic{Data: jsonData})
+	c.Writer.Flush()
+	return nil
+}

--- a/core/relay/adaptor/anthropic/render.go
+++ b/core/relay/adaptor/anthropic/render.go
@@ -19,7 +19,18 @@ func Data(c *gin.Context, data []byte) {
 	c.Writer.Flush()
 }
 
-func ObjectData(c *gin.Context, event string, object any) error {
+func EventData(c *gin.Context, event string, data []byte) {
+	if len(c.Errors) > 0 {
+		return
+	}
+	if c.IsAborted() {
+		return
+	}
+	c.Render(-1, &Anthropic{Event: event, Data: data})
+	c.Writer.Flush()
+}
+
+func ObjectData(c *gin.Context, object any) error {
 	if len(c.Errors) > 0 {
 		return c.Errors.Last()
 	}
@@ -31,6 +42,22 @@ func ObjectData(c *gin.Context, event string, object any) error {
 		return fmt.Errorf("error marshalling object: %w", err)
 	}
 	c.Render(-1, &Anthropic{Data: jsonData})
+	c.Writer.Flush()
+	return nil
+}
+
+func EventObjectData(c *gin.Context, event string, object any) error {
+	if len(c.Errors) > 0 {
+		return c.Errors.Last()
+	}
+	if c.IsAborted() {
+		return errors.New("context aborted")
+	}
+	jsonData, err := sonic.Marshal(object)
+	if err != nil {
+		return fmt.Errorf("error marshalling object: %w", err)
+	}
+	c.Render(-1, &Anthropic{Event: event, Data: jsonData})
 	c.Writer.Flush()
 	return nil
 }


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes Claude API's Server-Sent Events (SSE) implementation for raw endpoint streaming responses to properly handle event formatting.

- Added `core/relay/adaptor/anthropic/event.go` with a custom SSE renderer that properly formats Claude API events with event types and data.
- Created `core/relay/adaptor/anthropic/render.go` with helper functions for sending SSE data to clients in the correct format.
- Modified `core/relay/adaptor/anthropic/main.go` to use the new SSE rendering system instead of the generic renderer.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->