### PR TITLE
fix: ignore claude no used resp

### DIFF
--- a/core/relay/adaptor/anthropic/model.go
+++ b/core/relay/adaptor/anthropic/model.go
@@ -120,7 +120,7 @@ type ErrorResponse struct {
 }
 
 type Response struct {
-	StopReason   *string   `json:"stop_reason"`
+	StopReason   string    `json:"stop_reason,omitempty"`
 	StopSequence *string   `json:"stop_sequence"`
 	Error        *Error    `json:"error"`
 	ID           string    `json:"id"`

--- a/core/relay/model/misc.go
+++ b/core/relay/model/misc.go
@@ -50,8 +50,8 @@ func (u *Usage) Add(other *Usage) {
 }
 
 type PromptTokensDetails struct {
-	CachedTokens        int64 `json:"cached_tokens,omitempty"`
-	AudioTokens         int64 `json:"audio_tokens,omitempty"`
+	CachedTokens        int64 `json:"cached_tokens"`
+	AudioTokens         int64 `json:"audio_tokens"`
 	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
 }
 
@@ -65,10 +65,10 @@ func (d *PromptTokensDetails) Add(other *PromptTokensDetails) {
 }
 
 type CompletionTokensDetails struct {
-	ReasoningTokens          int64 `json:"reasoning_tokens,omitempty"`
-	AudioTokens              int64 `json:"audio_tokens,omitempty"`
-	AcceptedPredictionTokens int64 `json:"accepted_prediction_tokens,omitempty"`
-	RejectedPredictionTokens int64 `json:"rejected_prediction_tokens,omitempty"`
+	ReasoningTokens          int64 `json:"reasoning_tokens"`
+	AudioTokens              int64 `json:"audio_tokens"`
+	AcceptedPredictionTokens int64 `json:"accepted_prediction_tokens"`
+	RejectedPredictionTokens int64 `json:"rejected_prediction_tokens"`
 }
 
 type Error struct {


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes Claude API integration by properly handling null stop reasons and ignoring unnecessary response types in the streaming API.

- Changed `StopReason` in `core/relay/adaptor/anthropic/model.go` from a pointer to a string with `omitempty` to handle null values more gracefully.
- Modified `stopReasonClaude2OpenAI` in `core/relay/adaptor/anthropic/openai.go` to handle string values and added a case for "null" to return an empty string.
- Added explicit handling for "ping", "message_stop", and "content_block_stop" response types to be ignored in the streaming API.
- Restructured the response handling code to be more efficient by initializing variables directly rather than modifying them later.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->