### PR TITLE
feat: streamable http mcp support

### DIFF
--- a/core/common/mcpproxy/session.go
+++ b/core/common/mcpproxy/session.go
@@ -1,9 +1,14 @@
 package mcpproxy
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/labring/aiproxy/core/common"
+)
 
 // SessionManager defines the interface for managing session information
 type SessionManager interface {
+	New() (sessionID string)
 	// Set stores a sessionID and its corresponding backend endpoint
 	Set(sessionID, endpoint string)
 	// Get retrieves the backend endpoint for a sessionID
@@ -23,6 +28,10 @@ func NewMemStore() *MemStore {
 	return &MemStore{
 		sessions: make(map[string]string),
 	}
+}
+
+func (s *MemStore) New() string {
+	return common.ShortUUID()
 }
 
 // Set stores a sessionID and its corresponding backend endpoint

--- a/core/common/mcpproxy/sse_test.go
+++ b/core/common/mcpproxy/sse_test.go
@@ -14,8 +14,8 @@ import (
 
 type TestEndpointHandler struct{}
 
-func (h *TestEndpointHandler) NewEndpoint() (string, string) {
-	return "test-session-id", "/message?sessionId=test-session-id"
+func (h *TestEndpointHandler) NewEndpoint(_ string) string {
+	return "/message?sessionId=test-session-id"
 }
 
 func (h *TestEndpointHandler) LoadEndpoint(endpoint string) string {
@@ -50,7 +50,7 @@ func TestProxySSEEndpoint(t *testing.T) {
 	// Create the proxy
 	store := mcpproxy.NewMemStore()
 	handler := &TestEndpointHandler{}
-	proxy := mcpproxy.NewProxy(backendServer.URL+"/sse", nil, store, handler)
+	proxy := mcpproxy.NewSSEProxy(backendServer.URL+"/sse", nil, store, handler)
 
 	// Setup the proxy server
 	proxyServer := httptest.NewServer(http.HandlerFunc(proxy.SSEHandler))

--- a/core/common/mcpproxy/streamable.go
+++ b/core/common/mcpproxy/streamable.go
@@ -1,0 +1,463 @@
+package mcpproxy
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// StreamableProxy represents a proxy for the MCP Streamable HTTP transport
+type StreamableProxy struct {
+	store   SessionManager
+	backend string
+	headers map[string]string
+}
+
+// NewStreamableProxy creates a new proxy for the Streamable HTTP transport
+func NewStreamableProxy(backend string, headers map[string]string, store SessionManager) *StreamableProxy {
+	return &StreamableProxy{
+		store:   store,
+		backend: backend,
+		headers: headers,
+	}
+}
+
+// ServeHTTP handles both GET and POST requests for the Streamable HTTP transport
+func (p *StreamableProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Add CORS headers
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id")
+	w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+
+	// Handle preflight requests
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		p.handleGetRequest(w, r)
+	case http.MethodPost:
+		p.handlePostRequest(w, r)
+	case http.MethodDelete:
+		p.handleDeleteRequest(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleGetRequest handles GET requests for SSE streaming
+func (p *StreamableProxy) handleGetRequest(w http.ResponseWriter, r *http.Request) {
+	// Check if Accept header includes text/event-stream
+	acceptHeader := r.Header.Get("Accept")
+	if !strings.Contains(acceptHeader, "text/event-stream") {
+		http.Error(w, "Accept header must include text/event-stream", http.StatusBadRequest)
+		return
+	}
+
+	// Get proxy session ID from header
+	proxySessionID := r.Header.Get("Mcp-Session-Id")
+	if proxySessionID == "" {
+		// This might be an initialization request
+		p.proxyInitialOrNoSessionRequest(w, r)
+		return
+	}
+
+	// Look up the backend endpoint and session ID
+	backendInfo, ok := p.store.Get(proxySessionID)
+	if !ok {
+		http.Error(w, "Invalid or expired session ID", http.StatusNotFound)
+		return
+	}
+
+	// Create a request to the backend
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, backendInfo, nil)
+	if err != nil {
+		http.Error(w, "Failed to create backend request", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers from original request, but replace the session ID
+	for name, values := range r.Header {
+		if name == "Mcp-Session-Id" {
+			continue // Skip the proxy session ID
+		}
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+
+	// Extract the real backend session ID from the stored URL
+	parts := strings.Split(backendInfo, "?sessionId=")
+	if len(parts) > 1 {
+		req.Header.Set("Mcp-Session-Id", parts[1])
+	}
+
+	// Add any additional headers
+	for name, value := range p.headers {
+		req.Header.Set(name, value)
+	}
+
+	// Make the request to the backend
+	client := &http.Client{
+		Timeout: 0, // No timeout for SSE connections
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(w, "Failed to connect to backend", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Check if we got an SSE response
+	if resp.StatusCode != http.StatusOK || !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// Copy response headers, but not the backend session ID
+		for name, values := range resp.Header {
+			if name == "Mcp-Session-Id" {
+				continue
+			}
+			for _, value := range values {
+				w.Header().Add(name, value)
+			}
+		}
+		// Add our proxy session ID
+		w.Header().Set("Mcp-Session-Id", proxySessionID)
+
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+		return
+	}
+
+	// Set SSE headers for the client response
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Create a context that cancels when the client disconnects
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	// Monitor client disconnection
+	go func() {
+		<-ctx.Done()
+		resp.Body.Close()
+	}()
+
+	// Stream the SSE events to the client
+	reader := bufio.NewReader(resp.Body)
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return
+		}
+
+		// Write the line to the client
+		fmt.Fprint(w, line)
+		flusher.Flush()
+	}
+}
+
+// handlePostRequest handles POST requests for JSON-RPC messages
+func (p *StreamableProxy) handlePostRequest(w http.ResponseWriter, r *http.Request) {
+	// Check if this is an initialization request
+	proxySessionID := r.Header.Get("Mcp-Session-Id")
+	if proxySessionID == "" {
+		p.proxyInitialOrNoSessionRequest(w, r)
+		return
+	}
+
+	// Look up the backend endpoint and session ID
+	backendInfo, ok := p.store.Get(proxySessionID)
+	if !ok {
+		http.Error(w, "Invalid or expired session ID", http.StatusNotFound)
+		return
+	}
+
+	// Create a request to the backend
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, backendInfo, r.Body)
+	if err != nil {
+		http.Error(w, "Failed to create backend request", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers from original request, but replace the session ID
+	for name, values := range r.Header {
+		if name == "Mcp-Session-Id" {
+			continue // Skip the proxy session ID
+		}
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+
+	// Extract the real backend session ID from the stored URL
+	parts := strings.Split(backendInfo, "?sessionId=")
+	if len(parts) > 1 {
+		req.Header.Set("Mcp-Session-Id", parts[1])
+	}
+
+	// Add any additional headers
+	for name, value := range p.headers {
+		req.Header.Set(name, value)
+	}
+
+	// Make the request to the backend
+	client := &http.Client{
+		Timeout: time.Second * 30, // Use a timeout for regular requests
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(w, "Failed to connect to backend", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response headers, but not the backend session ID
+	for name, values := range resp.Header {
+		if name == "Mcp-Session-Id" {
+			continue
+		}
+		for _, value := range values {
+			w.Header().Add(name, value)
+		}
+	}
+	// Add our proxy session ID
+	w.Header().Set("Mcp-Session-Id", proxySessionID)
+
+	// Set response status code
+	w.WriteHeader(resp.StatusCode)
+
+	// Check if the response is an SSE stream
+	if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// Handle SSE response
+		reader := bufio.NewReader(resp.Body)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		// Create a context that cancels when the client disconnects
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+
+		// Monitor client disconnection
+		go func() {
+			<-ctx.Done()
+			resp.Body.Close()
+		}()
+
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return
+			}
+
+			// Write the line to the client
+			_, _ = fmt.Fprint(w, line)
+			flusher.Flush()
+		}
+	} else {
+		// Copy regular response body
+		_, _ = io.Copy(w, resp.Body)
+	}
+}
+
+// handleDeleteRequest handles DELETE requests for session termination
+func (p *StreamableProxy) handleDeleteRequest(w http.ResponseWriter, r *http.Request) {
+	// Get proxy session ID from header
+	proxySessionID := r.Header.Get("Mcp-Session-Id")
+	if proxySessionID == "" {
+		http.Error(w, "Missing session ID", http.StatusBadRequest)
+		return
+	}
+
+	// Look up the backend endpoint and session ID
+	backendInfo, ok := p.store.Get(proxySessionID)
+	if !ok {
+		http.Error(w, "Invalid or expired session ID", http.StatusNotFound)
+		return
+	}
+
+	// Create a request to the backend
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodDelete, backendInfo, nil)
+	if err != nil {
+		http.Error(w, "Failed to create backend request", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers from original request, but replace the session ID
+	for name, values := range r.Header {
+		if name == "Mcp-Session-Id" {
+			continue // Skip the proxy session ID
+		}
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+
+	// Extract the real backend session ID from the stored URL
+	parts := strings.Split(backendInfo, "?sessionId=")
+	if len(parts) > 1 {
+		req.Header.Set("Mcp-Session-Id", parts[1])
+	}
+
+	// Add any additional headers
+	for name, value := range p.headers {
+		req.Header.Set(name, value)
+	}
+
+	// Make the request to the backend
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(w, "Failed to connect to backend", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Remove the session from our store
+	p.store.Delete(proxySessionID)
+
+	// Copy response headers, but not the backend session ID
+	for name, values := range resp.Header {
+		if name == "Mcp-Session-Id" {
+			continue
+		}
+		for _, value := range values {
+			w.Header().Add(name, value)
+		}
+	}
+
+	// Set response status code
+	w.WriteHeader(resp.StatusCode)
+
+	// Copy response body
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// proxyInitialOrNoSessionRequest handles the initial request that doesn't have a session ID yet
+func (p *StreamableProxy) proxyInitialOrNoSessionRequest(w http.ResponseWriter, r *http.Request) {
+	// Create a request to the backend
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, p.backend, r.Body)
+	if err != nil {
+		http.Error(w, "Failed to create backend request", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers from original request
+	for name, values := range r.Header {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+
+	// Add any additional headers
+	for name, value := range p.headers {
+		req.Header.Set(name, value)
+	}
+
+	// Make the request to the backend
+	client := &http.Client{
+		Timeout: time.Second * 30,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(w, "Failed to connect to backend", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Check if we received a session ID from the backend
+	backendSessionID := resp.Header.Get("Mcp-Session-Id")
+	if backendSessionID != "" {
+		// Generate a new proxy session ID
+		proxySessionID := p.store.New()
+
+		// Store the mapping between our proxy session ID and the backend endpoint with its session ID
+		backendURL := p.backend
+		if strings.Contains(backendURL, "?") {
+			backendURL += "&sessionId=" + backendSessionID
+		} else {
+			backendURL += "?sessionId=" + backendSessionID
+		}
+		p.store.Set(proxySessionID, backendURL)
+
+		// Replace the backend session ID with our proxy session ID in the response
+		w.Header().Set("Mcp-Session-Id", proxySessionID)
+	}
+
+	// Copy other response headers
+	for name, values := range resp.Header {
+		if name != "Mcp-Session-Id" { // Skip the original session ID
+			for _, value := range values {
+				w.Header().Add(name, value)
+			}
+		}
+	}
+
+	// Set response status code
+	w.WriteHeader(resp.StatusCode)
+
+	// Check if the response is an SSE stream
+	if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// Handle SSE response
+		reader := bufio.NewReader(resp.Body)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		// Create a context that cancels when the client disconnects
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+
+		// Monitor client disconnection
+		go func() {
+			<-ctx.Done()
+			resp.Body.Close()
+		}()
+
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return
+			}
+
+			// Write the line to the client
+			fmt.Fprint(w, line)
+			flusher.Flush()
+		}
+	} else {
+		// Copy regular response body
+		_, _ = io.Copy(w, resp.Body)
+	}
+}

--- a/core/common/mcpproxy/streamable.go
+++ b/core/common/mcpproxy/streamable.go
@@ -104,12 +104,8 @@ func (p *StreamableProxy) handleGetRequest(w http.ResponseWriter, r *http.Reques
 		req.Header.Set(name, value)
 	}
 
-	// Make the request to the backend
-	client := &http.Client{
-		Timeout: 0, // No timeout for SSE connections
-	}
-
-	resp, err := client.Do(req)
+	//nolint:bodyclose
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		http.Error(w, "Failed to connect to backend", http.StatusInternalServerError)
 		return
@@ -131,7 +127,7 @@ func (p *StreamableProxy) handleGetRequest(w http.ResponseWriter, r *http.Reques
 		w.Header().Set("Mcp-Session-Id", proxySessionID)
 
 		w.WriteHeader(resp.StatusCode)
-		io.Copy(w, resp.Body)
+		_, _ = io.Copy(w, resp.Body)
 		return
 	}
 
@@ -217,12 +213,8 @@ func (p *StreamableProxy) handlePostRequest(w http.ResponseWriter, r *http.Reque
 		req.Header.Set(name, value)
 	}
 
-	// Make the request to the backend
-	client := &http.Client{
-		Timeout: time.Second * 30, // Use a timeout for regular requests
-	}
-
-	resp, err := client.Do(req)
+	//nolint:bodyclose
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		http.Error(w, "Failed to connect to backend", http.StatusInternalServerError)
 		return
@@ -380,12 +372,8 @@ func (p *StreamableProxy) proxyInitialOrNoSessionRequest(w http.ResponseWriter, 
 		req.Header.Set(name, value)
 	}
 
-	// Make the request to the backend
-	client := &http.Client{
-		Timeout: time.Second * 30,
-	}
-
-	resp, err := client.Do(req)
+	//nolint:bodyclose
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		http.Error(w, "Failed to connect to backend", http.StatusInternalServerError)
 		return

--- a/core/controller/mcp-sse.go
+++ b/core/controller/mcp-sse.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -69,7 +70,13 @@ func NewSSEServer(server *server.MCPServer, opts ...SSEOption) *SSEServer {
 // It sets up appropriate headers and creates a new session for the client.
 func (s *SSEServer) HandleSSE(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		errorResponse := CreateMCPErrorResponse(
+			nil,
+			mcp.METHOD_NOT_FOUND,
+			"method not allowed",
+		)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_ = sonic.ConfigDefault.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -80,7 +87,13 @@ func (s *SSEServer) HandleSSE(w http.ResponseWriter, r *http.Request) {
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		errorResponse := CreateMCPErrorResponse(
+			nil,
+			mcp.INTERNAL_ERROR,
+			"streaming unsupported",
+		)
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = sonic.ConfigDefault.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -122,8 +135,8 @@ func (s *SSEServer) HandleSSE(w http.ResponseWriter, r *http.Request) {
 func (s *SSEServer) HandleMessage(req []byte) error {
 	// Parse message as raw JSON
 	var rawMessage json.RawMessage
-	if err := json.Unmarshal(req, &rawMessage); err != nil {
-		return errors.New("parse error")
+	if err := sonic.Unmarshal(req, &rawMessage); err != nil {
+		return err
 	}
 
 	// Process message through MCPServer
@@ -131,7 +144,7 @@ func (s *SSEServer) HandleMessage(req []byte) error {
 
 	// Only send response if there is one (not for notifications)
 	if response != nil {
-		eventData, err := json.Marshal(response)
+		eventData, err := sonic.Marshal(response)
 		if err != nil {
 			return err
 		}
@@ -141,36 +154,10 @@ func (s *SSEServer) HandleMessage(req []byte) error {
 		case s.eventQueue <- fmt.Sprintf("event: message\ndata: %s\n\n", eventData):
 			// Event queued successfully
 		default:
-			// Queue is full, could log this
+			// Queue is full
+			return errors.New("event queue is full")
 		}
 	}
 
 	return nil
-}
-
-func JSONRPCError(
-	id interface{},
-	code int,
-	message string,
-) ([]byte, error) {
-	return json.Marshal(createErrorResponse(id, code, message))
-}
-
-func createErrorResponse(
-	id interface{},
-	code int,
-	message string,
-) mcp.JSONRPCMessage {
-	return mcp.JSONRPCError{
-		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      id,
-		Error: struct {
-			Code    int         `json:"code"`
-			Message string      `json:"message"`
-			Data    interface{} `json:"data,omitempty"`
-		}{
-			Code:    code,
-			Message: message,
-		},
-	}
 }

--- a/core/controller/mcp-sse.go
+++ b/core/controller/mcp-sse.go
@@ -47,6 +47,7 @@ func WithKeepAlive(keepAlive bool) SSEOption {
 }
 
 // NewSSEServer creates a new SSE server instance with the given MCP server and options.
+// TODO: notify support
 func NewSSEServer(server *server.MCPServer, opts ...SSEOption) *SSEServer {
 	s := &SSEServer{
 		server:            server,

--- a/core/controller/publicmcp-server.go
+++ b/core/controller/publicmcp-server.go
@@ -444,7 +444,8 @@ func handlePublicProxyStreamable(c *gin.Context, mcpID string, config *model.Pub
 		headers,
 	)
 
-	mcpproxy.NewStreamableProxy(backendURL.String(), headers, getStore())
+	mcpproxy.NewStreamableProxy(backendURL.String(), headers, getStore()).
+		ServeHTTP(c.Writer, c.Request)
 }
 
 // handleStreamableMCPServer handles the streamable connection for an MCP server

--- a/core/docs/docs.go
+++ b/core/docs/docs.go
@@ -6299,6 +6299,20 @@ const docTemplate = `{
                 "responses": {}
             }
         },
+        "/mcp/group/{id}/streamable": {
+            "get": {
+                "summary": "Group MCP Streamable Server",
+                "responses": {}
+            },
+            "post": {
+                "summary": "Group MCP Streamable Server",
+                "responses": {}
+            },
+            "delete": {
+                "summary": "Group MCP Streamable Server",
+                "responses": {}
+            }
+        },
         "/mcp/public/message": {
             "post": {
                 "summary": "Public MCP SSE Server",
@@ -8376,10 +8390,12 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "mcp_proxy_sse",
+                "mcp_proxy_streamable",
                 "mcp_openapi"
             ],
             "x-enum-varnames": [
                 "GroupMCPTypeProxySSE",
+                "GroupMCPTypeProxyStreamable",
                 "GroupMCPTypeOpenAPI"
             ]
         },

--- a/core/docs/docs.go
+++ b/core/docs/docs.go
@@ -6301,13 +6301,27 @@ const docTemplate = `{
         },
         "/mcp/public/message": {
             "post": {
-                "summary": "MCP SSE Proxy",
+                "summary": "Public MCP SSE Server",
                 "responses": {}
             }
         },
         "/mcp/public/{id}/sse": {
             "get": {
                 "summary": "Public MCP SSE Server",
+                "responses": {}
+            }
+        },
+        "/mcp/public/{id}/streamable": {
+            "get": {
+                "summary": "Public MCP Streamable Server",
+                "responses": {}
+            },
+            "post": {
+                "summary": "Public MCP Streamable Server",
+                "responses": {}
+            },
+            "delete": {
+                "summary": "Public MCP Streamable Server",
                 "responses": {}
             }
         },
@@ -8327,8 +8341,8 @@ const docTemplate = `{
                 "openapi_config": {
                     "$ref": "#/definitions/model.MCPOpenAPIConfig"
                 },
-                "proxy_sse_config": {
-                    "$ref": "#/definitions/model.GroupMCPProxySSEConfig"
+                "proxy_config": {
+                    "$ref": "#/definitions/model.GroupMCPProxyConfig"
                 },
                 "type": {
                     "$ref": "#/definitions/model.GroupMCPType"
@@ -8338,7 +8352,7 @@ const docTemplate = `{
                 }
             }
         },
-        "model.GroupMCPProxySSEConfig": {
+        "model.GroupMCPProxyConfig": {
             "type": "object",
             "properties": {
                 "headers": {
@@ -8568,7 +8582,7 @@ const docTemplate = `{
                 "openapi_spec": {
                     "type": "string"
                 },
-                "server": {
+                "server_addr": {
                     "type": "string"
                 },
                 "v2": {
@@ -8871,8 +8885,8 @@ const docTemplate = `{
                 "price": {
                     "$ref": "#/definitions/model.MCPPrice"
                 },
-                "proxy_sse_config": {
-                    "$ref": "#/definitions/model.PublicMCPProxySSEConfig"
+                "proxy_config": {
+                    "$ref": "#/definitions/model.PublicMCPProxyConfig"
                 },
                 "readme": {
                     "type": "string"
@@ -8897,7 +8911,7 @@ const docTemplate = `{
                 }
             }
         },
-        "model.PublicMCPProxySSEConfig": {
+        "model.PublicMCPProxyConfig": {
             "type": "object",
             "properties": {
                 "headers": {
@@ -8950,6 +8964,7 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "mcp_proxy_sse",
+                "mcp_proxy_streamable",
                 "mcp_git_repo",
                 "mcp_openapi"
             ],
@@ -8958,6 +8973,7 @@ const docTemplate = `{
             },
             "x-enum-varnames": [
                 "PublicMCPTypeProxySSE",
+                "PublicMCPTypeProxyStreamable",
                 "PublicMCPTypeGitRepo",
                 "PublicMCPTypeOpenAPI"
             ]

--- a/core/docs/swagger.json
+++ b/core/docs/swagger.json
@@ -6290,6 +6290,20 @@
                 "responses": {}
             }
         },
+        "/mcp/group/{id}/streamable": {
+            "get": {
+                "summary": "Group MCP Streamable Server",
+                "responses": {}
+            },
+            "post": {
+                "summary": "Group MCP Streamable Server",
+                "responses": {}
+            },
+            "delete": {
+                "summary": "Group MCP Streamable Server",
+                "responses": {}
+            }
+        },
         "/mcp/public/message": {
             "post": {
                 "summary": "Public MCP SSE Server",
@@ -8367,10 +8381,12 @@
             "type": "string",
             "enum": [
                 "mcp_proxy_sse",
+                "mcp_proxy_streamable",
                 "mcp_openapi"
             ],
             "x-enum-varnames": [
                 "GroupMCPTypeProxySSE",
+                "GroupMCPTypeProxyStreamable",
                 "GroupMCPTypeOpenAPI"
             ]
         },

--- a/core/docs/swagger.json
+++ b/core/docs/swagger.json
@@ -6292,13 +6292,27 @@
         },
         "/mcp/public/message": {
             "post": {
-                "summary": "MCP SSE Proxy",
+                "summary": "Public MCP SSE Server",
                 "responses": {}
             }
         },
         "/mcp/public/{id}/sse": {
             "get": {
                 "summary": "Public MCP SSE Server",
+                "responses": {}
+            }
+        },
+        "/mcp/public/{id}/streamable": {
+            "get": {
+                "summary": "Public MCP Streamable Server",
+                "responses": {}
+            },
+            "post": {
+                "summary": "Public MCP Streamable Server",
+                "responses": {}
+            },
+            "delete": {
+                "summary": "Public MCP Streamable Server",
                 "responses": {}
             }
         },
@@ -8318,8 +8332,8 @@
                 "openapi_config": {
                     "$ref": "#/definitions/model.MCPOpenAPIConfig"
                 },
-                "proxy_sse_config": {
-                    "$ref": "#/definitions/model.GroupMCPProxySSEConfig"
+                "proxy_config": {
+                    "$ref": "#/definitions/model.GroupMCPProxyConfig"
                 },
                 "type": {
                     "$ref": "#/definitions/model.GroupMCPType"
@@ -8329,7 +8343,7 @@
                 }
             }
         },
-        "model.GroupMCPProxySSEConfig": {
+        "model.GroupMCPProxyConfig": {
             "type": "object",
             "properties": {
                 "headers": {
@@ -8559,7 +8573,7 @@
                 "openapi_spec": {
                     "type": "string"
                 },
-                "server": {
+                "server_addr": {
                     "type": "string"
                 },
                 "v2": {
@@ -8862,8 +8876,8 @@
                 "price": {
                     "$ref": "#/definitions/model.MCPPrice"
                 },
-                "proxy_sse_config": {
-                    "$ref": "#/definitions/model.PublicMCPProxySSEConfig"
+                "proxy_config": {
+                    "$ref": "#/definitions/model.PublicMCPProxyConfig"
                 },
                 "readme": {
                     "type": "string"
@@ -8888,7 +8902,7 @@
                 }
             }
         },
-        "model.PublicMCPProxySSEConfig": {
+        "model.PublicMCPProxyConfig": {
             "type": "object",
             "properties": {
                 "headers": {
@@ -8941,6 +8955,7 @@
             "type": "string",
             "enum": [
                 "mcp_proxy_sse",
+                "mcp_proxy_streamable",
                 "mcp_git_repo",
                 "mcp_openapi"
             ],
@@ -8949,6 +8964,7 @@
             },
             "x-enum-varnames": [
                 "PublicMCPTypeProxySSE",
+                "PublicMCPTypeProxyStreamable",
                 "PublicMCPTypeGitRepo",
                 "PublicMCPTypeOpenAPI"
             ]

--- a/core/docs/swagger.yaml
+++ b/core/docs/swagger.yaml
@@ -805,14 +805,14 @@ definitions:
         type: string
       openapi_config:
         $ref: '#/definitions/model.MCPOpenAPIConfig'
-      proxy_sse_config:
-        $ref: '#/definitions/model.GroupMCPProxySSEConfig'
+      proxy_config:
+        $ref: '#/definitions/model.GroupMCPProxyConfig'
       type:
         $ref: '#/definitions/model.GroupMCPType'
       update_at:
         type: string
     type: object
-  model.GroupMCPProxySSEConfig:
+  model.GroupMCPProxyConfig:
     properties:
       headers:
         additionalProperties:
@@ -964,7 +964,7 @@ definitions:
         type: string
       openapi_spec:
         type: string
-      server:
+      server_addr:
         type: string
       v2:
         type: boolean
@@ -1185,8 +1185,8 @@ definitions:
         $ref: '#/definitions/model.MCPOpenAPIConfig'
       price:
         $ref: '#/definitions/model.MCPPrice'
-      proxy_sse_config:
-        $ref: '#/definitions/model.PublicMCPProxySSEConfig'
+      proxy_config:
+        $ref: '#/definitions/model.PublicMCPProxyConfig'
       readme:
         type: string
       readme_url:
@@ -1202,7 +1202,7 @@ definitions:
       update_at:
         type: string
     type: object
-  model.PublicMCPProxySSEConfig:
+  model.PublicMCPProxyConfig:
     properties:
       headers:
         additionalProperties:
@@ -1237,6 +1237,7 @@ definitions:
   model.PublicMCPType:
     enum:
     - mcp_proxy_sse
+    - mcp_proxy_streamable
     - mcp_git_repo
     - mcp_openapi
     type: string
@@ -1244,6 +1245,7 @@ definitions:
       PublicMCPTypeGitRepo: read only
     x-enum-varnames:
     - PublicMCPTypeProxySSE
+    - PublicMCPTypeProxyStreamable
     - PublicMCPTypeGitRepo
     - PublicMCPTypeOpenAPI
   model.RequestDetail:
@@ -5207,10 +5209,20 @@ paths:
     get:
       responses: {}
       summary: Public MCP SSE Server
+  /mcp/public/{id}/streamable:
+    delete:
+      responses: {}
+      summary: Public MCP Streamable Server
+    get:
+      responses: {}
+      summary: Public MCP Streamable Server
+    post:
+      responses: {}
+      summary: Public MCP Streamable Server
   /mcp/public/message:
     post:
       responses: {}
-      summary: MCP SSE Proxy
+      summary: Public MCP SSE Server
   /v1/audio/speech:
     post:
       description: AudioSpeech

--- a/core/docs/swagger.yaml
+++ b/core/docs/swagger.yaml
@@ -828,10 +828,12 @@ definitions:
   model.GroupMCPType:
     enum:
     - mcp_proxy_sse
+    - mcp_proxy_streamable
     - mcp_openapi
     type: string
     x-enum-varnames:
     - GroupMCPTypeProxySSE
+    - GroupMCPTypeProxyStreamable
     - GroupMCPTypeOpenAPI
   model.GroupModelConfig:
     properties:
@@ -5201,6 +5203,16 @@ paths:
     get:
       responses: {}
       summary: Group MCP SSE Server
+  /mcp/group/{id}/streamable:
+    delete:
+      responses: {}
+      summary: Group MCP Streamable Server
+    get:
+      responses: {}
+      summary: Group MCP Streamable Server
+    post:
+      responses: {}
+      summary: Group MCP Streamable Server
   /mcp/group/message:
     post:
       responses: {}

--- a/core/model/groupmcp.go
+++ b/core/model/groupmcp.go
@@ -16,8 +16,9 @@ const (
 type GroupMCPType string
 
 const (
-	GroupMCPTypeProxySSE GroupMCPType = "mcp_proxy_sse"
-	GroupMCPTypeOpenAPI  GroupMCPType = "mcp_openapi"
+	GroupMCPTypeProxySSE        GroupMCPType = "mcp_proxy_sse"
+	GroupMCPTypeProxyStreamable GroupMCPType = "mcp_proxy_streamable"
+	GroupMCPTypeOpenAPI         GroupMCPType = "mcp_openapi"
 )
 
 type GroupMCPProxyConfig struct {

--- a/core/model/groupmcp.go
+++ b/core/model/groupmcp.go
@@ -20,22 +20,22 @@ const (
 	GroupMCPTypeOpenAPI  GroupMCPType = "mcp_openapi"
 )
 
-type GroupMCPProxySSEConfig struct {
+type GroupMCPProxyConfig struct {
 	URL     string            `json:"url"`
 	Querys  map[string]string `json:"querys"`
 	Headers map[string]string `json:"headers"`
 }
 
 type GroupMCP struct {
-	ID             string                  `gorm:"primaryKey"                    json:"id"`
-	GroupID        string                  `gorm:"primaryKey"                    json:"group_id"`
-	Group          *Group                  `gorm:"foreignKey:GroupID"            json:"-"`
-	CreatedAt      time.Time               `gorm:"index"                         json:"created_at"`
-	UpdateAt       time.Time               `gorm:"index"                         json:"update_at"`
-	Name           string                  `json:"name"`
-	Type           GroupMCPType            `gorm:"index"                         json:"type"`
-	ProxySSEConfig *GroupMCPProxySSEConfig `gorm:"serializer:fastjson;type:text" json:"proxy_sse_config,omitempty"`
-	OpenAPIConfig  *MCPOpenAPIConfig       `gorm:"serializer:fastjson;type:text" json:"openapi_config,omitempty"`
+	ID            string               `gorm:"primaryKey"                    json:"id"`
+	GroupID       string               `gorm:"primaryKey"                    json:"group_id"`
+	Group         *Group               `gorm:"foreignKey:GroupID"            json:"-"`
+	CreatedAt     time.Time            `gorm:"index"                         json:"created_at"`
+	UpdateAt      time.Time            `gorm:"index"                         json:"update_at"`
+	Name          string               `json:"name"`
+	Type          GroupMCPType         `gorm:"index"                         json:"type"`
+	ProxyConfig   *GroupMCPProxyConfig `gorm:"serializer:fastjson;type:text" json:"proxy_config,omitempty"`
+	OpenAPIConfig *MCPOpenAPIConfig    `gorm:"serializer:fastjson;type:text" json:"openapi_config,omitempty"`
 }
 
 func (g *GroupMCP) BeforeCreate(_ *gorm.DB) (err error) {
@@ -57,8 +57,8 @@ func (g *GroupMCP) BeforeCreate(_ *gorm.DB) (err error) {
 		return errors.New("openapi spec and content is empty")
 	}
 
-	if g.ProxySSEConfig != nil {
-		config := g.ProxySSEConfig
+	if g.ProxyConfig != nil {
+		config := g.ProxyConfig
 		return validateHTTPURL(config.URL)
 	}
 

--- a/core/model/publicmcp.go
+++ b/core/model/publicmcp.go
@@ -18,9 +18,10 @@ const (
 type PublicMCPType string
 
 const (
-	PublicMCPTypeProxySSE PublicMCPType = "mcp_proxy_sse"
-	PublicMCPTypeGitRepo  PublicMCPType = "mcp_git_repo" // read only
-	PublicMCPTypeOpenAPI  PublicMCPType = "mcp_openapi"
+	PublicMCPTypeProxySSE        PublicMCPType = "mcp_proxy_sse"
+	PublicMCPTypeProxyStreamable PublicMCPType = "mcp_proxy_streamable"
+	PublicMCPTypeGitRepo         PublicMCPType = "mcp_git_repo" // read only
+	PublicMCPTypeOpenAPI         PublicMCPType = "mcp_openapi"
 )
 
 type ParamType string
@@ -42,7 +43,7 @@ type MCPPrice struct {
 	ToolsCallPrices       map[string]float64 `gorm:"serializer:fastjson;type:text" json:"tools_call_prices"`
 }
 
-type PublicMCPProxySSEConfig struct {
+type PublicMCPProxyConfig struct {
 	URL           string                  `json:"url"`
 	Querys        map[string]string       `json:"querys"`
 	Headers       map[string]string       `json:"headers"`
@@ -91,21 +92,21 @@ type MCPOpenAPIConfig struct {
 }
 
 type PublicMCP struct {
-	ID                     string                   `gorm:"primaryKey"                    json:"id"`
-	CreatedAt              time.Time                `gorm:"index"                         json:"created_at"`
-	UpdateAt               time.Time                `gorm:"index"                         json:"update_at"`
-	PublicMCPReusingParams []PublicMCPReusingParam  `gorm:"foreignKey:MCPID"              json:"-"`
-	Name                   string                   `json:"name"`
-	Type                   PublicMCPType            `gorm:"index"                         json:"type"`
-	RepoURL                string                   `json:"repo_url"`
-	ReadmeURL              string                   `json:"readme_url"`
-	Readme                 string                   `gorm:"type:text"                     json:"readme"`
-	Tags                   []string                 `gorm:"serializer:fastjson;type:text" json:"tags,omitempty"`
-	Author                 string                   `json:"author"`
-	LogoURL                string                   `json:"logo_url"`
-	Price                  MCPPrice                 `gorm:"embedded"                      json:"price"`
-	ProxySSEConfig         *PublicMCPProxySSEConfig `gorm:"serializer:fastjson;type:text" json:"proxy_sse_config,omitempty"`
-	OpenAPIConfig          *MCPOpenAPIConfig        `gorm:"serializer:fastjson;type:text" json:"openapi_config,omitempty"`
+	ID                     string                  `gorm:"primaryKey"                    json:"id"`
+	CreatedAt              time.Time               `gorm:"index"                         json:"created_at"`
+	UpdateAt               time.Time               `gorm:"index"                         json:"update_at"`
+	PublicMCPReusingParams []PublicMCPReusingParam `gorm:"foreignKey:MCPID"              json:"-"`
+	Name                   string                  `json:"name"`
+	Type                   PublicMCPType           `gorm:"index"                         json:"type"`
+	RepoURL                string                  `json:"repo_url"`
+	ReadmeURL              string                  `json:"readme_url"`
+	Readme                 string                  `gorm:"type:text"                     json:"readme"`
+	Tags                   []string                `gorm:"serializer:fastjson;type:text" json:"tags,omitempty"`
+	Author                 string                  `json:"author"`
+	LogoURL                string                  `json:"logo_url"`
+	Price                  MCPPrice                `gorm:"embedded"                      json:"price"`
+	ProxyConfig            *PublicMCPProxyConfig   `gorm:"serializer:fastjson;type:text" json:"proxy_config,omitempty"`
+	OpenAPIConfig          *MCPOpenAPIConfig       `gorm:"serializer:fastjson;type:text" json:"openapi_config,omitempty"`
 }
 
 func (p *PublicMCP) BeforeCreate(_ *gorm.DB) error {
@@ -124,8 +125,8 @@ func (p *PublicMCP) BeforeCreate(_ *gorm.DB) error {
 		return errors.New("openapi spec and content is empty")
 	}
 
-	if p.ProxySSEConfig != nil {
-		config := p.ProxySSEConfig
+	if p.ProxyConfig != nil {
+		config := p.ProxyConfig
 		return validateHTTPURL(config.URL)
 	}
 	return nil

--- a/core/router/mcp.go
+++ b/core/router/mcp.go
@@ -17,4 +17,7 @@ func SetMCPRouter(router *gin.Engine) {
 
 	mcpRoute.GET("/group/:id/sse", controller.GroupMCPSseServer)
 	mcpRoute.POST("/group/message", controller.GroupMCPMessage)
+	mcpRoute.GET("/group/:id/streamable", controller.GroupMCPStreamable)
+	mcpRoute.POST("/group/:id/streamable", controller.GroupMCPStreamable)
+	mcpRoute.DELETE("/group/:id/streamable", controller.GroupMCPStreamable)
 }

--- a/core/router/mcp.go
+++ b/core/router/mcp.go
@@ -11,6 +11,9 @@ func SetMCPRouter(router *gin.Engine) {
 
 	mcpRoute.GET("/public/:id/sse", controller.PublicMCPSseServer)
 	mcpRoute.POST("/public/message", controller.PublicMCPMessage)
+	mcpRoute.GET("/public/:id/streamable", controller.PublicMCPStreamable)
+	mcpRoute.POST("/public/:id/streamable", controller.PublicMCPStreamable)
+	mcpRoute.DELETE("/public/:id/streamable", controller.PublicMCPStreamable)
 
 	mcpRoute.GET("/group/:id/sse", controller.GroupMCPSseServer)
 	mcpRoute.POST("/group/message", controller.GroupMCPMessage)


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds support for streamable HTTP MCP (Message Control Protocol) transport alongside the existing SSE-based implementation.

- Added new `StreamableProxy` in `core/common/mcpproxy/streamable.go` that implements HTTP-based MCP communication with session management.
- Updated `SessionManager` interface to include a `New()` method for generating session IDs.
- Renamed `Proxy` to `SSEAProxy` and `ProxySSEConfig` to `ProxyConfig` for better abstraction across transport types.
- Added new endpoints in router for handling streamable HTTP requests for both public and group MCPs.
- Updated models to support the new streamable proxy type alongside the existing SSE implementation.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->