### PR TITLE
fix: mutli splitter heads

### DIFF
--- a/core/common/splitter/splitter.go
+++ b/core/common/splitter/splitter.go
@@ -88,10 +88,9 @@ func (s *Splitter) Process(data []byte) ([]byte, []byte) {
 					headMatched = true
 					headMatchLen = headLen
 					break
-				} else {
-					// Mark this head as impossible to match
-					s.impossibleHeads[i] = true
 				}
+				// Mark this head as impossible to match
+				s.impossibleHeads[i] = true
 			} else {
 				// Check for partial match (potential match)
 				matchLen := bufLen

--- a/core/common/splitter/think.go
+++ b/core/common/splitter/think.go
@@ -3,15 +3,17 @@ package splitter
 import "github.com/labring/aiproxy/core/common/conv"
 
 const (
-	ThinkHead = "<think>\n"
-	ThinkTail = "</think>\n"
+	NThinkHead = "\n<think>\n"
+	ThinkHead  = "<think>\n"
+	ThinkTail  = "</think>\n"
 )
 
 var (
-	thinkHeadBytes = conv.StringToBytes(ThinkHead)
-	thinkTailBytes = conv.StringToBytes(ThinkTail)
+	nthinkHeadBytes = conv.StringToBytes(NThinkHead)
+	thinkHeadBytes  = conv.StringToBytes(ThinkHead)
+	thinkTailBytes  = conv.StringToBytes(ThinkTail)
 )
 
 func NewThinkSplitter() *Splitter {
-	return NewSplitter(thinkHeadBytes, thinkTailBytes)
+	return NewSplitter([][]byte{nthinkHeadBytes, thinkHeadBytes}, [][]byte{thinkTailBytes})
 }

--- a/core/relay/adaptor/openai/main.go
+++ b/core/relay/adaptor/openai/main.go
@@ -417,6 +417,8 @@ func Handler(meta *meta.Meta, c *gin.Context, resp *http.Response, preHandler Pr
 			return usage.ToModelUsage(), ErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError)
 		}
 		SplitThink(respMap)
+		c.JSON(http.StatusOK, respMap)
+		return usage.ToModelUsage(), nil
 	}
 
 	newData, err := sonic.Marshal(&node)


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Enhanced the text splitter to support multiple head patterns for more robust think/reasoning content extraction in AI responses.

- Refactored `core/common/splitter/splitter.go` to handle multiple head and tail patterns instead of just single patterns.
- Added support for newline-prefixed think tags in `core/common/splitter/think.go` with the new `NThinkHead` constant.
- Fixed response handling in `core/relay/adaptor/openai/main.go` to properly return JSON after splitting think content.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->