### PR TITLE
fix: audio opus duration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=builder /aiproxy/core/aiproxy /usr/local/bin/aiproxy
 
 ENV PUID=0 PGID=0 UMASK=022
 
-ENV FFPROBE_ENABLED=true
+ENV FFMPEG_ENABLED=true
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker-compose up -d
 - `LISTEN`: The listen address, default is `:3000`
 - `ADMIN_KEY`: The admin key for the AI Proxy Service, admin key is used to admin api and relay api, default is empty
 - `INTERNAL_TOKEN`: Internal token for service authentication, default is empty
-- `FFPROBE_ENABLED`: Whether to enable ffprobe, default is `false`
+- `FFMPEG_ENABLED`: Whether to enable ffmpeg, default is `false`
 
 ### Debug Options
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,7 +69,7 @@ docker-compose up -d
 - `LISTEN`: 监听地址，默认 `:3000`
 - `ADMIN_KEY`: 管理员密钥，用于管理 API 和转发 API，默认空
 - `INTERNAL_TOKEN`: 内部服务认证 token，默认空
-- `FFPROBE_ENABLED`: 是否启用 ffprobe，默认 `false`
+- `FFMPEG_ENABLED`: 是否启用 ffmpeg，默认 `false`
 
 ### Debug 选项
 

--- a/core/common/audio/audio.go
+++ b/core/common/audio/audio.go
@@ -1,19 +1,24 @@
 package audio
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/labring/aiproxy/core/common/config"
 )
 
-var ErrAudioDurationNAN = errors.New("audio duration is N/A")
+var (
+	ErrAudioDurationNAN = errors.New("audio duration is N/A")
+	re                  = regexp.MustCompile(`time=(\d+:\d+:\d+\.\d+)`)
+)
 
 func GetAudioDuration(audio io.Reader) (float64, error) {
-	if !config.FfprobeEnabled {
+	if !config.FfmpegEnabled {
 		return 0, nil
 	}
 
@@ -34,7 +39,15 @@ func GetAudioDuration(audio io.Reader) (float64, error) {
 	str := strings.TrimSpace(string(output))
 
 	if str == "" || str == "N/A" {
-		return 0, ErrAudioDurationNAN
+		seeker, ok := audio.(io.Seeker)
+		if !ok {
+			return 0, ErrAudioDurationNAN
+		}
+		_, err := seeker.Seek(0, io.SeekStart)
+		if err != nil {
+			return 0, ErrAudioDurationNAN
+		}
+		return getAudioDurationFallback(audio)
 	}
 
 	duration, err := strconv.ParseFloat(str, 64)
@@ -44,8 +57,31 @@ func GetAudioDuration(audio io.Reader) (float64, error) {
 	return duration, nil
 }
 
+func getAudioDurationFallback(audio io.Reader) (float64, error) {
+	if !config.FfmpegEnabled {
+		return 0, nil
+	}
+
+	ffmpegCmd := exec.Command(
+		"ffmpeg",
+		"-i", "-",
+		"-f", "null", "-",
+	)
+	ffmpegCmd.Stdin = audio
+	var stderr bytes.Buffer
+	ffmpegCmd.Stderr = &stderr
+	err := ffmpegCmd.Run()
+	if err != nil {
+		return 0, err
+	}
+
+	// Parse the time from ffmpeg output
+	// Example: size=N/A time=00:00:05.52 bitrate=N/A speed= 785x
+	return parseTimeFromFfmpegOutput(stderr.String())
+}
+
 func GetAudioDurationFromFilePath(filePath string) (float64, error) {
-	if !config.FfprobeEnabled {
+	if !config.FfmpegEnabled {
 		return 0, nil
 	}
 
@@ -65,12 +101,67 @@ func GetAudioDurationFromFilePath(filePath string) (float64, error) {
 	str := strings.TrimSpace(string(output))
 
 	if str == "" || str == "N/A" {
-		return 0, ErrAudioDurationNAN
+		return getAudioDurationFromFilePathFallback(filePath)
 	}
 
 	duration, err := strconv.ParseFloat(str, 64)
 	if err != nil {
 		return 0, err
 	}
+	return duration, nil
+}
+
+func getAudioDurationFromFilePathFallback(filePath string) (float64, error) {
+	if !config.FfmpegEnabled {
+		return 0, nil
+	}
+
+	ffmpegCmd := exec.Command(
+		"ffmpeg",
+		"-i", filePath,
+		"-f", "null", "-",
+	)
+
+	var stderr bytes.Buffer
+	ffmpegCmd.Stderr = &stderr
+	err := ffmpegCmd.Run()
+	if err != nil {
+		return 0, err
+	}
+
+	// Parse the time from ffmpeg output
+	return parseTimeFromFfmpegOutput(stderr.String())
+}
+
+// parseTimeFromFfmpegOutput extracts and converts time from ffmpeg output to seconds
+func parseTimeFromFfmpegOutput(output string) (float64, error) {
+	match := re.FindStringSubmatch(output)
+	if len(match) < 2 {
+		return 0, ErrAudioDurationNAN
+	}
+
+	// Convert time format HH:MM:SS.MS to seconds
+	timeStr := match[1]
+	parts := strings.Split(timeStr, ":")
+	if len(parts) != 3 {
+		return 0, errors.New("invalid time format")
+	}
+
+	hours, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return 0, err
+	}
+
+	minutes, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil {
+		return 0, err
+	}
+
+	seconds, err := strconv.ParseFloat(parts[2], 64)
+	if err != nil {
+		return 0, err
+	}
+
+	duration := hours*3600 + minutes*60 + seconds
 	return duration, nil
 }

--- a/core/common/config/config.go
+++ b/core/common/config/config.go
@@ -18,7 +18,7 @@ var (
 var (
 	DisableAutoMigrateDB = env.Bool("DISABLE_AUTO_MIGRATE_DB", false)
 	AdminKey             = os.Getenv("ADMIN_KEY")
-	FfprobeEnabled       = env.Bool("FFPROBE_ENABLED", false)
+	FfmpegEnabled        = env.Bool("FFMPEG_ENABLED", false)
 )
 
 var (


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes audio duration detection for opus format files by implementing ffmpeg fallback when ffprobe fails to determine duration.

- Renamed environment variable from `FFPROBE_ENABLED` to `FFMPEG_ENABLED` in configuration files and documentation.
- Added fallback mechanism in `core/common/audio/audio.go` that uses ffmpeg when ffprobe returns empty or "N/A" duration.
- Implemented new functions to parse time from ffmpeg output using regex pattern matching.
- Set `FFMPEG_ENABLED=true` by default in the Dockerfile to ensure audio duration detection works out of the box.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->