### PR TITLE
feat: jina embed support

### DIFF
--- a/core/relay/adaptor/baidu/adaptor.go
+++ b/core/relay/adaptor/baidu/adaptor.go
@@ -92,8 +92,7 @@ func (a *Adaptor) SetupRequestHeader(meta *meta.Meta, _ *gin.Context, req *http.
 func (a *Adaptor) ConvertRequest(meta *meta.Meta, req *http.Request) (string, http.Header, io.Reader, error) {
 	switch meta.Mode {
 	case mode.Embeddings:
-		meta.Set(openai.MetaEmbeddingsPatchInputToSlices, true)
-		return openai.ConvertRequest(meta, req)
+		return openai.ConvertEmbeddingsRequest(meta, req, true)
 	case mode.Rerank:
 		return openai.ConvertRequest(meta, req)
 	case mode.ImagesGenerations:

--- a/core/relay/adaptor/jina/embeddings.go
+++ b/core/relay/adaptor/jina/embeddings.go
@@ -1,4 +1,4 @@
-package openai
+package jina
 
 import (
 	"bytes"
@@ -11,7 +11,7 @@ import (
 )
 
 //nolint:gocritic
-func ConvertEmbeddingsRequest(meta *meta.Meta, req *http.Request, inputToSlices bool) (string, http.Header, io.Reader, error) {
+func ConvertEmbeddingsRequest(meta *meta.Meta, req *http.Request) (string, http.Header, io.Reader, error) {
 	reqMap := make(map[string]any)
 	err := common.UnmarshalBodyReusable(req, &reqMap)
 	if err != nil {
@@ -20,12 +20,12 @@ func ConvertEmbeddingsRequest(meta *meta.Meta, req *http.Request, inputToSlices 
 
 	reqMap["model"] = meta.ActualModel
 
-	if inputToSlices {
-		switch v := reqMap["input"].(type) {
-		case string:
-			reqMap["input"] = []string{v}
-		}
+	switch v := reqMap["input"].(type) {
+	case string:
+		reqMap["input"] = []string{v}
 	}
+
+	delete(reqMap, "encoding_format")
 
 	jsonData, err := sonic.Marshal(reqMap)
 	if err != nil {

--- a/core/relay/adaptor/openai/adaptor.go
+++ b/core/relay/adaptor/openai/adaptor.go
@@ -75,10 +75,9 @@ func ConvertRequest(meta *meta.Meta, req *http.Request) (string, http.Header, io
 	}
 	switch meta.Mode {
 	case mode.Moderations:
-		meta.Set(MetaEmbeddingsPatchInputToSlices, true)
-		return ConvertEmbeddingsRequest(meta, req)
+		return ConvertEmbeddingsRequest(meta, req, true)
 	case mode.Embeddings, mode.Completions:
-		return ConvertEmbeddingsRequest(meta, req)
+		return ConvertEmbeddingsRequest(meta, req, false)
 	case mode.ChatCompletions:
 		return ConvertTextRequest(meta, req, false)
 	case mode.ImagesGenerations:


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Added support for Jina AI embeddings by implementing request conversion and response handling for the embeddings mode.

- Created new `embeddings.go` file in the Jina adaptor to handle embedding request conversion specifically for Jina AI.
- Updated the Jina adaptor to properly handle embeddings mode by implementing the `ConvertRequest` method.
- Modified the OpenAI embeddings function to use an explicit boolean parameter instead of metadata flags for better reusability.
- Updated the Baidu adaptor to use the refactored OpenAI embeddings function with the new parameter.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->