### PR TITLE
feat: deprecated fron log query

### DIFF
--- a/core/controller/dashboard.go
+++ b/core/controller/dashboard.go
@@ -152,7 +152,6 @@ func fillGaps(data []*model.ChartData, start, end time.Time, t model.TimeSpanTyp
 //	@Param			token_usage		query		bool	false	"Token usage"
 //	@Param			start_timestamp	query		int64	false	"Start second timestamp"
 //	@Param			end_timestamp	query		int64	false	"End second timestamp"
-//	@Param			from_log		query		bool	false	"From log"
 //	@Param			timezone		query		string	false	"Timezone, default is Local"
 //	@Success		200				{object}	middleware.APIResponse{data=model.DashboardResponse}
 //	@Router			/api/dashboard [get]
@@ -168,11 +167,10 @@ func GetDashboard(c *gin.Context) {
 	resultOnly, _ := strconv.ParseBool(c.Query("result_only"))
 	tokenUsage, _ := strconv.ParseBool(c.Query("token_usage"))
 	channelID, _ := strconv.Atoi(c.Query("channel"))
-	fromLog, _ := strconv.ParseBool(c.Query("from_log"))
 
 	needRPM := channelID != 0
 
-	dashboards, err := model.GetDashboardData(group, start, end, modelName, channelID, timeSpan, resultOnly, needRPM, tokenUsage, fromLog, timezoneLocation)
+	dashboards, err := model.GetDashboardData(group, start, end, modelName, channelID, timeSpan, resultOnly, needRPM, tokenUsage, timezoneLocation)
 	if err != nil {
 		middleware.ErrorResponse(c, http.StatusOK, err.Error())
 		return
@@ -207,7 +205,6 @@ func GetDashboard(c *gin.Context) {
 //	@Param			token_usage		query		bool	false	"Token usage"
 //	@Param			start_timestamp	query		int64	false	"Start second timestamp"
 //	@Param			end_timestamp	query		int64	false	"End second timestamp"
-//	@Param			from_log		query		bool	false	"From log"
 //	@Param			timezone		query		string	false	"Timezone, default is Local"
 //	@Success		200				{object}	middleware.APIResponse{data=model.GroupDashboardResponse}
 //	@Router			/api/dashboard/{group} [get]
@@ -228,11 +225,10 @@ func GetGroupDashboard(c *gin.Context) {
 	modelName := c.Query("model")
 	resultOnly, _ := strconv.ParseBool(c.Query("result_only"))
 	tokenUsage, _ := strconv.ParseBool(c.Query("token_usage"))
-	fromLog, _ := strconv.ParseBool(c.Query("from_log"))
 
 	needRPM := tokenName != ""
 
-	dashboards, err := model.GetGroupDashboardData(group, start, end, tokenName, modelName, timeSpan, resultOnly, needRPM, tokenUsage, fromLog, timezoneLocation)
+	dashboards, err := model.GetGroupDashboardData(group, start, end, tokenName, modelName, timeSpan, resultOnly, needRPM, tokenUsage, timezoneLocation)
 	if err != nil {
 		middleware.ErrorResponse(c, http.StatusOK, "failed to get statistics")
 		return
@@ -305,17 +301,13 @@ func GetGroupDashboardModels(c *gin.Context) {
 //	@Param			channel			query		int		false	"Channel ID"
 //	@Param			start_timestamp	query		int64	false	"Start timestamp"
 //	@Param			end_timestamp	query		int64	false	"End timestamp"
-//	@Param			token_usage		query		bool	false	"Token usage"
-//	@Param			from_log		query		bool	false	"From log"
 //	@Success		200				{object}	middleware.APIResponse{data=[]model.ModelCostRank}
 //	@Router			/api/model_cost_rank [get]
 func GetModelCostRank(c *gin.Context) {
 	group := c.Query("group")
 	channelID, _ := strconv.Atoi(c.Query("channel"))
 	startTime, endTime := parseTimeRange(c)
-	tokenUsage, _ := strconv.ParseBool(c.Query("token_usage"))
-	fromLog, _ := strconv.ParseBool(c.Query("from_log"))
-	models, err := model.GetModelCostRank(group, channelID, startTime, endTime, tokenUsage, fromLog)
+	models, err := model.GetModelCostRank(group, channelID, startTime, endTime)
 	if err != nil {
 		middleware.ErrorResponse(c, http.StatusOK, err.Error())
 		return
@@ -333,8 +325,6 @@ func GetModelCostRank(c *gin.Context) {
 //	@Param			group			path		string	true	"Group"
 //	@Param			start_timestamp	query		int64	false	"Start timestamp"
 //	@Param			end_timestamp	query		int64	false	"End timestamp"
-//	@Param			token_usage		query		bool	false	"Token usage"
-//	@Param			from_log		query		bool	false	"From log"
 //	@Success		200				{object}	middleware.APIResponse{data=[]model.ModelCostRank}
 //	@Router			/api/model_cost_rank/{group} [get]
 func GetGroupModelCostRank(c *gin.Context) {
@@ -344,9 +334,7 @@ func GetGroupModelCostRank(c *gin.Context) {
 		return
 	}
 	startTime, endTime := parseTimeRange(c)
-	tokenUsage, _ := strconv.ParseBool(c.Query("token_usage"))
-	fromLog, _ := strconv.ParseBool(c.Query("from_log"))
-	models, err := model.GetModelCostRank(group, 0, startTime, endTime, tokenUsage, fromLog)
+	models, err := model.GetModelCostRank(group, 0, startTime, endTime)
 	if err != nil {
 		middleware.ErrorResponse(c, http.StatusOK, err.Error())
 		return

--- a/core/controller/dashboard.go
+++ b/core/controller/dashboard.go
@@ -148,8 +148,6 @@ func fillGaps(data []*model.ChartData, start, end time.Time, t model.TimeSpanTyp
 //	@Param			channel			query		int		false	"Channel ID"
 //	@Param			type			query		string	false	"Type of time span (day, week, month, two_week)"
 //	@Param			model			query		string	false	"Model name"
-//	@Param			result_only		query		bool	false	"Only return result"
-//	@Param			token_usage		query		bool	false	"Token usage"
 //	@Param			start_timestamp	query		int64	false	"Start second timestamp"
 //	@Param			end_timestamp	query		int64	false	"End second timestamp"
 //	@Param			timezone		query		string	false	"Timezone, default is Local"
@@ -164,13 +162,11 @@ func GetDashboard(c *gin.Context) {
 	timezoneLocation, _ := time.LoadLocation(c.DefaultQuery("timezone", "Local"))
 	start, end, timeSpan := getDashboardTime(c.Query("type"), startTimestamp, endTimestamp, timezoneLocation)
 	modelName := c.Query("model")
-	resultOnly, _ := strconv.ParseBool(c.Query("result_only"))
-	tokenUsage, _ := strconv.ParseBool(c.Query("token_usage"))
 	channelID, _ := strconv.Atoi(c.Query("channel"))
 
 	needRPM := channelID != 0
 
-	dashboards, err := model.GetDashboardData(group, start, end, modelName, channelID, timeSpan, resultOnly, needRPM, tokenUsage, timezoneLocation)
+	dashboards, err := model.GetDashboardData(group, start, end, modelName, channelID, timeSpan, needRPM, timezoneLocation)
 	if err != nil {
 		middleware.ErrorResponse(c, http.StatusOK, err.Error())
 		return
@@ -201,8 +197,6 @@ func GetDashboard(c *gin.Context) {
 //	@Param			type			query		string	false	"Type of time span (day, week, month, two_week)"
 //	@Param			token_name		query		string	false	"Token name"
 //	@Param			model			query		string	false	"Model or *"
-//	@Param			result_only		query		bool	false	"Only return result"
-//	@Param			token_usage		query		bool	false	"Token usage"
 //	@Param			start_timestamp	query		int64	false	"Start second timestamp"
 //	@Param			end_timestamp	query		int64	false	"End second timestamp"
 //	@Param			timezone		query		string	false	"Timezone, default is Local"
@@ -223,12 +217,10 @@ func GetGroupDashboard(c *gin.Context) {
 	start, end, timeSpan := getDashboardTime(c.Query("type"), startTimestamp, endTimestamp, timezoneLocation)
 	tokenName := c.Query("token_name")
 	modelName := c.Query("model")
-	resultOnly, _ := strconv.ParseBool(c.Query("result_only"))
-	tokenUsage, _ := strconv.ParseBool(c.Query("token_usage"))
 
 	needRPM := tokenName != ""
 
-	dashboards, err := model.GetGroupDashboardData(group, start, end, tokenName, modelName, timeSpan, resultOnly, needRPM, tokenUsage, timezoneLocation)
+	dashboards, err := model.GetGroupDashboardData(group, start, end, tokenName, modelName, timeSpan, needRPM, timezoneLocation)
 	if err != nil {
 		middleware.ErrorResponse(c, http.StatusOK, "failed to get statistics")
 		return

--- a/core/docs/docs.go
+++ b/core/docs/docs.go
@@ -1002,18 +1002,6 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "boolean",
-                        "description": "Only return result",
-                        "name": "result_only",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Token usage",
-                        "name": "token_usage",
-                        "in": "query"
-                    },
-                    {
                         "type": "integer",
                         "description": "Start second timestamp",
                         "name": "start_timestamp",
@@ -1093,18 +1081,6 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Model or *",
                         "name": "model",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Only return result",
-                        "name": "result_only",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Token usage",
-                        "name": "token_usage",
                         "in": "query"
                     },
                     {

--- a/core/docs/docs.go
+++ b/core/docs/docs.go
@@ -1026,12 +1026,6 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "boolean",
-                        "description": "From log",
-                        "name": "from_log",
-                        "in": "query"
-                    },
-                    {
                         "type": "string",
                         "description": "Timezone, default is Local",
                         "name": "timezone",
@@ -1123,12 +1117,6 @@ const docTemplate = `{
                         "type": "integer",
                         "description": "End second timestamp",
                         "name": "end_timestamp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "From log",
-                        "name": "from_log",
                         "in": "query"
                     },
                     {
@@ -4298,18 +4286,6 @@ const docTemplate = `{
                         "description": "End timestamp",
                         "name": "end_timestamp",
                         "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Token usage",
-                        "name": "token_usage",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "From log",
-                        "name": "from_log",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -4370,18 +4346,6 @@ const docTemplate = `{
                         "type": "integer",
                         "description": "End timestamp",
                         "name": "end_timestamp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Token usage",
-                        "name": "token_usage",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "From log",
-                        "name": "from_log",
                         "in": "query"
                     }
                 ],
@@ -8564,9 +8528,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "retry_times": {
-                    "type": "integer"
-                },
-                "timestamp_trunc_by_hour": {
                     "type": "integer"
                 },
                 "token_id": {

--- a/core/docs/swagger.json
+++ b/core/docs/swagger.json
@@ -993,18 +993,6 @@
                         "in": "query"
                     },
                     {
-                        "type": "boolean",
-                        "description": "Only return result",
-                        "name": "result_only",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Token usage",
-                        "name": "token_usage",
-                        "in": "query"
-                    },
-                    {
                         "type": "integer",
                         "description": "Start second timestamp",
                         "name": "start_timestamp",
@@ -1084,18 +1072,6 @@
                         "type": "string",
                         "description": "Model or *",
                         "name": "model",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Only return result",
-                        "name": "result_only",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Token usage",
-                        "name": "token_usage",
                         "in": "query"
                     },
                     {

--- a/core/docs/swagger.json
+++ b/core/docs/swagger.json
@@ -1017,12 +1017,6 @@
                         "in": "query"
                     },
                     {
-                        "type": "boolean",
-                        "description": "From log",
-                        "name": "from_log",
-                        "in": "query"
-                    },
-                    {
                         "type": "string",
                         "description": "Timezone, default is Local",
                         "name": "timezone",
@@ -1114,12 +1108,6 @@
                         "type": "integer",
                         "description": "End second timestamp",
                         "name": "end_timestamp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "From log",
-                        "name": "from_log",
                         "in": "query"
                     },
                     {
@@ -4289,18 +4277,6 @@
                         "description": "End timestamp",
                         "name": "end_timestamp",
                         "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Token usage",
-                        "name": "token_usage",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "From log",
-                        "name": "from_log",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -4361,18 +4337,6 @@
                         "type": "integer",
                         "description": "End timestamp",
                         "name": "end_timestamp",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Token usage",
-                        "name": "token_usage",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "From log",
-                        "name": "from_log",
                         "in": "query"
                     }
                 ],
@@ -8555,9 +8519,6 @@
                     "type": "string"
                 },
                 "retry_times": {
-                    "type": "integer"
-                },
-                "timestamp_trunc_by_hour": {
                     "type": "integer"
                 },
                 "token_id": {

--- a/core/docs/swagger.yaml
+++ b/core/docs/swagger.yaml
@@ -945,8 +945,6 @@ definitions:
         type: string
       retry_times:
         type: integer
-      timestamp_trunc_by_hour:
-        type: integer
       token_id:
         type: integer
       token_name:
@@ -2026,10 +2024,6 @@ paths:
         in: query
         name: end_timestamp
         type: integer
-      - description: From log
-        in: query
-        name: from_log
-        type: boolean
       - description: Timezone, default is Local
         in: query
         name: timezone
@@ -2088,10 +2082,6 @@ paths:
         in: query
         name: end_timestamp
         type: integer
-      - description: From log
-        in: query
-        name: from_log
-        type: boolean
       - description: Timezone, default is Local
         in: query
         name: timezone
@@ -4008,14 +3998,6 @@ paths:
         in: query
         name: end_timestamp
         type: integer
-      - description: Token usage
-        in: query
-        name: token_usage
-        type: boolean
-      - description: From log
-        in: query
-        name: from_log
-        type: boolean
       produces:
       - application/json
       responses:
@@ -4052,14 +4034,6 @@ paths:
         in: query
         name: end_timestamp
         type: integer
-      - description: Token usage
-        in: query
-        name: token_usage
-        type: boolean
-      - description: From log
-        in: query
-        name: from_log
-        type: boolean
       produces:
       - application/json
       responses:

--- a/core/docs/swagger.yaml
+++ b/core/docs/swagger.yaml
@@ -2008,14 +2008,6 @@ paths:
         in: query
         name: model
         type: string
-      - description: Only return result
-        in: query
-        name: result_only
-        type: boolean
-      - description: Token usage
-        in: query
-        name: token_usage
-        type: boolean
       - description: Start second timestamp
         in: query
         name: start_timestamp
@@ -2066,14 +2058,6 @@ paths:
         in: query
         name: model
         type: string
-      - description: Only return result
-        in: query
-        name: result_only
-        type: boolean
-      - description: Token usage
-        in: query
-        name: token_usage
-        type: boolean
       - description: Start second timestamp
         in: query
         name: start_timestamp

--- a/core/model/log.go
+++ b/core/model/log.go
@@ -114,29 +114,28 @@ func (u *Usage) Add(other *Usage) {
 }
 
 type Log struct {
-	RequestDetail        *RequestDetail  `gorm:"foreignKey:LogID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"request_detail,omitempty"`
-	RequestAt            time.Time       `gorm:"index"                                                          json:"request_at"`
-	RetryAt              time.Time       `json:"retry_at,omitempty"`
-	TTFBMilliseconds     ZeroNullInt64   `json:"ttfb_milliseconds,omitempty"`
-	TimestampTruncByHour int64           `json:"timestamp_trunc_by_hour"`
-	CreatedAt            time.Time       `gorm:"autoCreateTime;index"                                           json:"created_at"`
-	TokenName            string          `json:"token_name,omitempty"`
-	Endpoint             EmptyNullString `json:"endpoint,omitempty"`
-	Content              EmptyNullString `gorm:"type:text"                                                      json:"content,omitempty"`
-	GroupID              string          `json:"group,omitempty"`
-	Model                string          `json:"model"`
-	RequestID            EmptyNullString `gorm:"index:,where:request_id is not null"                            json:"request_id"`
-	ID                   int             `gorm:"primaryKey"                                                     json:"id"`
-	TokenID              int             `gorm:"index"                                                          json:"token_id,omitempty"`
-	ChannelID            int             `json:"channel,omitempty"`
-	Code                 int             `gorm:"index"                                                          json:"code,omitempty"`
-	Mode                 int             `json:"mode,omitempty"`
-	IP                   EmptyNullString `gorm:"index:,where:ip is not null"                                    json:"ip,omitempty"`
-	RetryTimes           ZeroNullInt64   `json:"retry_times,omitempty"`
-	DownstreamResult     bool            `json:"downstream_result,omitempty"`
-	Price                Price           `gorm:"embedded"                                                       json:"price,omitempty"`
-	Usage                Usage           `gorm:"embedded"                                                       json:"usage,omitempty"`
-	UsedAmount           float64         `json:"used_amount,omitempty"`
+	RequestDetail    *RequestDetail  `gorm:"foreignKey:LogID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"request_detail,omitempty"`
+	RequestAt        time.Time       `gorm:"index"                                                          json:"request_at"`
+	RetryAt          time.Time       `json:"retry_at,omitempty"`
+	TTFBMilliseconds ZeroNullInt64   `json:"ttfb_milliseconds,omitempty"`
+	CreatedAt        time.Time       `gorm:"autoCreateTime;index"                                           json:"created_at"`
+	TokenName        string          `json:"token_name,omitempty"`
+	Endpoint         EmptyNullString `json:"endpoint,omitempty"`
+	Content          EmptyNullString `gorm:"type:text"                                                      json:"content,omitempty"`
+	GroupID          string          `json:"group,omitempty"`
+	Model            string          `json:"model"`
+	RequestID        EmptyNullString `gorm:"index:,where:request_id is not null"                            json:"request_id"`
+	ID               int             `gorm:"primaryKey"                                                     json:"id"`
+	TokenID          int             `gorm:"index"                                                          json:"token_id,omitempty"`
+	ChannelID        int             `json:"channel,omitempty"`
+	Code             int             `gorm:"index"                                                          json:"code,omitempty"`
+	Mode             int             `json:"mode,omitempty"`
+	IP               EmptyNullString `gorm:"index:,where:ip is not null"                                    json:"ip,omitempty"`
+	RetryTimes       ZeroNullInt64   `json:"retry_times,omitempty"`
+	DownstreamResult bool            `json:"downstream_result,omitempty"`
+	Price            Price           `gorm:"embedded"                                                       json:"price,omitempty"`
+	Usage            Usage           `gorm:"embedded"                                                       json:"usage,omitempty"`
+	UsedAmount       float64         `json:"used_amount,omitempty"`
 }
 
 func CreateLogIndexes(db *gorm.DB) error {
@@ -151,11 +150,6 @@ func CreateLogIndexes(db *gorm.DB) error {
 			// used by global search logs
 			"CREATE INDEX IF NOT EXISTS idx_channel_model_reqat ON logs (channel_id, model, request_at DESC)",
 
-			// global hour indexes, used by global dashboard
-			"CREATE INDEX IF NOT EXISTS idx_model_trunchour ON logs (model, timestamp_trunc_by_hour)",
-			"CREATE INDEX IF NOT EXISTS idx_channel_trunchour ON logs (channel_id, timestamp_trunc_by_hour)",
-			"CREATE INDEX IF NOT EXISTS idx_channel_model_trunchour ON logs (channel_id, model, timestamp_trunc_by_hour)",
-
 			// used by search group logs
 			"CREATE INDEX IF NOT EXISTS idx_group_reqat ON logs (group_id, request_at DESC)",
 			// used by search group logs
@@ -164,12 +158,6 @@ func CreateLogIndexes(db *gorm.DB) error {
 			"CREATE INDEX IF NOT EXISTS idx_group_model_reqat ON logs (group_id, model, request_at DESC)",
 			// used by search group logs
 			"CREATE INDEX IF NOT EXISTS idx_group_token_model_reqat ON logs (group_id, token_name, model, request_at DESC)",
-
-			// hour indexes, used by dashboard
-			"CREATE INDEX IF NOT EXISTS idx_group_trunchour ON logs (group_id, timestamp_trunc_by_hour DESC)",
-			"CREATE INDEX IF NOT EXISTS idx_group_model_trunchour ON logs (group_id, model, timestamp_trunc_by_hour DESC)",
-			"CREATE INDEX IF NOT EXISTS idx_group_token_trunchour ON logs (group_id, token_name, timestamp_trunc_by_hour DESC)",
-			"CREATE INDEX IF NOT EXISTS idx_group_model_token_trunchour ON logs (group_id, model, token_name, timestamp_trunc_by_hour DESC)",
 		}
 	} else {
 		indexes = []string{
@@ -180,11 +168,6 @@ func CreateLogIndexes(db *gorm.DB) error {
 			// used by global search logs
 			"CREATE INDEX IF NOT EXISTS idx_channel_model_reqat ON logs (channel_id, model, request_at DESC) INCLUDE (code, downstream_result)",
 
-			// global hour indexes, used by global dashboard
-			"CREATE INDEX IF NOT EXISTS idx_model_trunchour ON logs (model, timestamp_trunc_by_hour) INCLUDE (downstream_result)",
-			"CREATE INDEX IF NOT EXISTS idx_channel_trunchour ON logs (channel_id, timestamp_trunc_by_hour) INCLUDE (downstream_result)",
-			"CREATE INDEX IF NOT EXISTS idx_channel_model_trunchour ON logs (channel_id, model, timestamp_trunc_by_hour) INCLUDE (downstream_result)",
-
 			// used by search group logs
 			"CREATE INDEX IF NOT EXISTS idx_group_reqat ON logs (group_id, request_at DESC) INCLUDE (code, downstream_result)",
 			// used by search group logs
@@ -193,12 +176,6 @@ func CreateLogIndexes(db *gorm.DB) error {
 			"CREATE INDEX IF NOT EXISTS idx_group_model_reqat ON logs (group_id, model, request_at DESC) INCLUDE (code, downstream_result)",
 			// used by search group logs
 			"CREATE INDEX IF NOT EXISTS idx_group_token_model_reqat ON logs (group_id, token_name, model, request_at DESC) INCLUDE (code, downstream_result)",
-
-			// hour indexes, used by dashboard
-			"CREATE INDEX IF NOT EXISTS idx_group_trunchour ON logs (group_id, timestamp_trunc_by_hour DESC) INCLUDE (downstream_result)",
-			"CREATE INDEX IF NOT EXISTS idx_group_model_trunchour ON logs (group_id, model, timestamp_trunc_by_hour DESC) INCLUDE (downstream_result)",
-			"CREATE INDEX IF NOT EXISTS idx_group_token_trunchour ON logs (group_id, token_name, timestamp_trunc_by_hour DESC) INCLUDE (downstream_result)",
-			"CREATE INDEX IF NOT EXISTS idx_group_model_token_trunchour ON logs (group_id, model, token_name, timestamp_trunc_by_hour DESC) INCLUDE (downstream_result)",
 		}
 	}
 
@@ -224,9 +201,6 @@ func (l *Log) BeforeCreate(_ *gorm.DB) (err error) {
 	}
 	if l.RequestAt.IsZero() {
 		l.RequestAt = l.CreatedAt
-	}
-	if l.TimestampTruncByHour == 0 {
-		l.TimestampTruncByHour = l.RequestAt.Truncate(time.Hour).Unix()
 	}
 	return
 }
@@ -1122,71 +1096,6 @@ const (
 	TimeSpanHour TimeSpanType = "hour"
 )
 
-func getChartDataFromLog(
-	group string,
-	start, end time.Time,
-	tokenName, modelName string,
-	channelID int,
-	timeSpan TimeSpanType,
-	resultOnly bool, tokenUsage bool,
-	timezone *time.Location,
-) ([]*ChartData, error) {
-	var query *gorm.DB
-	if tokenUsage {
-		query = LogDB.Table("logs").
-			Select("timestamp_trunc_by_hour as timestamp, count(*) as request_count, sum(used_amount) as used_amount, sum(case when code != 200 then 1 else 0 end) as exception_count, sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(cached_tokens) as cached_tokens, sum(cache_creation_tokens) as cache_creation_tokens, sum(total_tokens) as total_tokens, sum(web_search_count) as web_search_count").
-			Group("timestamp").
-			Order("timestamp ASC")
-	} else {
-		query = LogDB.Table("logs").
-			Select("timestamp_trunc_by_hour as timestamp, count(*) as request_count, sum(used_amount) as used_amount, sum(case when code != 200 then 1 else 0 end) as exception_count").
-			Group("timestamp").
-			Order("timestamp ASC")
-	}
-
-	if group == "" {
-		query = query.Where("group_id = ''")
-	} else if group != "*" {
-		query = query.Where("group_id = ?", group)
-	}
-
-	if channelID != 0 {
-		query = query.Where("channel_id = ?", channelID)
-	}
-	if modelName != "" {
-		query = query.Where("model = ?", modelName)
-	}
-	if tokenName != "" {
-		query = query.Where("token_name = ?", tokenName)
-	}
-
-	switch {
-	case !start.IsZero() && !end.IsZero():
-		query = query.Where("timestamp_trunc_by_hour BETWEEN ? AND ?", start.Unix(), end.Unix())
-	case !start.IsZero():
-		query = query.Where("timestamp_trunc_by_hour >= ?", start.Unix())
-	case !end.IsZero():
-		query = query.Where("timestamp_trunc_by_hour <= ?", end.Unix())
-	}
-
-	if resultOnly {
-		query = query.Where("downstream_result = true")
-	}
-
-	var chartData []*ChartData
-	err := query.Scan(&chartData).Error
-	if err != nil {
-		return nil, err
-	}
-
-	// If timeSpan is day, aggregate hour data into day data
-	if timeSpan == TimeSpanDay && len(chartData) > 0 {
-		return aggregateHourDataToDay(chartData, timezone), nil
-	}
-
-	return chartData, nil
-}
-
 // aggregateHourDataToDay converts hourly chart data into daily aggregated data
 func aggregateHourDataToDay(hourlyData []*ChartData, timezone *time.Location) []*ChartData {
 	dayData := make(map[int64]*ChartData)
@@ -1359,7 +1268,6 @@ func GetDashboardData(
 	resultOnly bool,
 	needRPM bool,
 	tokenUsage bool,
-	fromLog bool,
 	timezone *time.Location,
 ) (*DashboardResponse, error) {
 	if end.IsZero() {
@@ -1377,19 +1285,11 @@ func GetDashboardData(
 
 	g := new(errgroup.Group)
 
-	if fromLog {
-		g.Go(func() error {
-			var err error
-			chartData, err = getChartDataFromLog(group, start, end, "", modelName, channelID, timeSpan, resultOnly, tokenUsage, timezone)
-			return err
-		})
-	} else {
-		g.Go(func() error {
-			var err error
-			chartData, err = getChartData(group, start, end, "", modelName, channelID, timeSpan, timezone)
-			return err
-		})
-	}
+	g.Go(func() error {
+		var err error
+		chartData, err = getChartData(group, start, end, "", modelName, channelID, timeSpan, timezone)
+		return err
+	})
 
 	if needRPM {
 		g.Go(func() error {
@@ -1405,19 +1305,11 @@ func GetDashboardData(
 		return err
 	})
 
-	if fromLog {
-		g.Go(func() error {
-			var err error
-			channels, err = GetUsedChannelsFromLog(group, start, end)
-			return err
-		})
-	} else {
-		g.Go(func() error {
-			var err error
-			channels, err = GetUsedChannels(group, start, end)
-			return err
-		})
-	}
+	g.Go(func() error {
+		var err error
+		channels, err = GetUsedChannels(group, start, end)
+		return err
+	})
 
 	if err := g.Wait(); err != nil {
 		return nil, err
@@ -1440,7 +1332,6 @@ func GetGroupDashboardData(
 	resultOnly bool,
 	needRPM bool,
 	tokenUsage bool,
-	fromLog bool,
 	timezone *time.Location,
 ) (*GroupDashboardResponse, error) {
 	if group == "" || group == "*" {
@@ -1463,19 +1354,11 @@ func GetGroupDashboardData(
 
 	g := new(errgroup.Group)
 
-	if fromLog {
-		g.Go(func() error {
-			var err error
-			chartData, err = getChartDataFromLog(group, start, end, tokenName, modelName, 0, timeSpan, resultOnly, tokenUsage, timezone)
-			return err
-		})
-	} else {
-		g.Go(func() error {
-			var err error
-			chartData, err = getChartData(group, start, end, tokenName, modelName, 0, timeSpan, timezone)
-			return err
-		})
-	}
+	g.Go(func() error {
+		var err error
+		chartData, err = getChartData(group, start, end, tokenName, modelName, 0, timeSpan, timezone)
+		return err
+	})
 
 	g.Go(func() error {
 		var err error
@@ -1541,67 +1424,6 @@ type ModelCostRank struct {
 	TotalTokens         int64   `json:"total_tokens"`
 	RequestCount        int64   `json:"request_count"`
 	WebSearchCount      int64   `json:"web_search_count"`
-}
-
-func GetModelCostRank(group string, channelID int, start, end time.Time, tokenUsage bool, fromLog bool) ([]*ModelCostRank, error) {
-	if fromLog {
-		return getModelCostRankFromLog(group, channelID, start, end, tokenUsage)
-	}
-	return getModelCostRank(group, channelID, start, end)
-}
-
-func getModelCostRankFromLog(group string, channelID int, start, end time.Time, tokenUsage bool) ([]*ModelCostRank, error) {
-	var ranks []*ModelCostRank
-
-	var query *gorm.DB
-	if tokenUsage {
-		query = LogDB.Model(&Log{}).
-			Select("model, SUM(used_amount) as used_amount, SUM(input_tokens) as input_tokens, SUM(output_tokens) as output_tokens, SUM(cached_tokens) as cached_tokens, SUM(cache_creation_tokens) as cache_creation_tokens, SUM(total_tokens) as total_tokens, COUNT(*) as request_count, SUM(web_search_count) as web_search_count").
-			Group("model")
-	} else {
-		query = LogDB.Model(&Log{}).
-			Select("model, SUM(used_amount) as used_amount, COUNT(*) as request_count").
-			Group("model")
-	}
-
-	if group == "" {
-		query = query.Where("group_id = ''")
-	} else if group != "*" {
-		query = query.Where("group_id = ?", group)
-	}
-
-	if channelID != 0 {
-		query = query.Where("channel_id = ?", channelID)
-	}
-
-	switch {
-	case !start.IsZero() && !end.IsZero():
-		query = query.Where("request_at BETWEEN ? AND ?", start, end)
-	case !start.IsZero():
-		query = query.Where("request_at >= ?", start)
-	case !end.IsZero():
-		query = query.Where("request_at <= ?", end)
-	}
-
-	err := query.Scan(&ranks).Error
-	if err != nil {
-		return nil, err
-	}
-
-	slices.SortFunc(ranks, func(a, b *ModelCostRank) int {
-		if a.UsedAmount != b.UsedAmount {
-			return cmp.Compare(b.UsedAmount, a.UsedAmount)
-		}
-		if a.TotalTokens != b.TotalTokens {
-			return cmp.Compare(b.TotalTokens, a.TotalTokens)
-		}
-		if a.RequestCount != b.RequestCount {
-			return cmp.Compare(b.RequestCount, a.RequestCount)
-		}
-		return cmp.Compare(a.Model, b.Model)
-	})
-
-	return ranks, nil
 }
 
 func GetIPGroups(threshold int, start, end time.Time) (map[string][]string, error) {

--- a/core/model/log.go
+++ b/core/model/log.go
@@ -1265,9 +1265,7 @@ func GetDashboardData(
 	modelName string,
 	channelID int,
 	timeSpan TimeSpanType,
-	resultOnly bool,
 	needRPM bool,
-	tokenUsage bool,
 	timezone *time.Location,
 ) (*DashboardResponse, error) {
 	if end.IsZero() {
@@ -1329,9 +1327,7 @@ func GetGroupDashboardData(
 	tokenName string,
 	modelName string,
 	timeSpan TimeSpanType,
-	resultOnly bool,
 	needRPM bool,
-	tokenUsage bool,
 	timezone *time.Location,
 ) (*GroupDashboardResponse, error) {
 	if group == "" || group == "*" {

--- a/core/model/summary.go
+++ b/core/model/summary.go
@@ -274,7 +274,7 @@ func getLogGroupByValues[T cmp.Ordered](field string, group string, start, end t
 	return values, nil
 }
 
-func getModelCostRank(group string, channelID int, start, end time.Time) ([]*ModelCostRank, error) {
+func GetModelCostRank(group string, channelID int, start, end time.Time) ([]*ModelCostRank, error) {
 	var ranks []*ModelCostRank
 
 	var query *gorm.DB


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Removes the deprecated "from_log" query parameter and related functionality from dashboard endpoints to simplify the codebase.

- Removed the `from_log` parameter from dashboard API endpoints in `core/controller/dashboard.go` to standardize data retrieval methods.
- Deleted the `TimestampTruncByHour` field from the `Log` struct and removed related database indexes in `core/model/log.go`.
- Removed functions that queried log data directly (`getChartDataFromLog`, `GetModelCostRankFromLog`) in favor of using summary tables.
- Made `getModelCostRank` public by renaming it to `GetModelCostRank` in `core/model/summary.go` since the wrapper function was removed.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->