### PR TITLE
fix: ali stt usage

### DIFF
--- a/core/relay/adaptor/ali/stt-realtime.go
+++ b/core/relay/adaptor/ali/stt-realtime.go
@@ -215,6 +215,10 @@ func STTDoResponse(meta *meta.Meta, c *gin.Context, _ *http.Response) (usage *mo
 			usage.TotalTokens = msg.Payload.Usage.Characters
 			c.JSON(http.StatusOK, gin.H{
 				"text": output.String(),
+				"usage": relaymodel.Usage{
+					PromptTokens: usage.InputTokens,
+					TotalTokens:  usage.TotalTokens,
+				},
 			})
 			return usage, nil
 		case "task-failed":

--- a/core/relay/adaptor/openai/stt.go
+++ b/core/relay/adaptor/openai/stt.go
@@ -124,8 +124,10 @@ func STTHandler(meta *meta.Meta, c *gin.Context, resp *http.Response) (*model.Us
 	}
 
 	var respData []byte
-	switch responseFormat {
-	case "text", "json":
+	switch {
+	case responseFormat == "text",
+		responseFormat == "json",
+		strings.Contains(resp.Header.Get("Content-Type"), "json"):
 		node, err := sonic.Get(responseBody)
 		if err != nil {
 			return usage.ToModelUsage(), ErrorWrapper(err, "get_node_from_body_err", http.StatusInternalServerError)


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes the Alibaba Cloud Speech-to-Text (STT) usage reporting and improves OpenAI STT response format handling.

- Added missing `usage` field to the JSON response in `core/relay/adaptor/ali/stt-realtime.go` to properly report token usage information.
- Enhanced the response format detection in `core/relay/adaptor/openai/stt.go` to also check Content-Type headers containing "json" in addition to explicit format specifications.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->