### PR TITLE
feat: retry delay when suing same channel

### DIFF
--- a/core/relay/adaptor/gemini/main.go
+++ b/core/relay/adaptor/gemini/main.go
@@ -614,10 +614,6 @@ func StreamHandler(meta *meta.Meta, c *gin.Context, resp *http.Response) (*model
 		}
 		data = data[6:]
 
-		if conv.BytesToString(data) == "[DONE]" {
-			break
-		}
-
 		var geminiResponse ChatResponse
 		err := sonic.Unmarshal(data, &geminiResponse)
 		if err != nil {

--- a/core/relay/adaptor/xai/error.go
+++ b/core/relay/adaptor/xai/error.go
@@ -3,6 +3,7 @@ package xai
 import (
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/bytedance/sonic"
 	"github.com/labring/aiproxy/core/common/conv"
@@ -28,5 +29,12 @@ func ErrorHandler(resp *http.Response) *model.ErrorWithStatusCode {
 	if err != nil {
 		return openai.ErrorWrapperWithMessage(conv.BytesToString(data), nil, http.StatusInternalServerError)
 	}
-	return openai.ErrorWrapperWithMessage(er.Error, er.Code, resp.StatusCode)
+
+	statusCode := resp.StatusCode
+
+	if strings.Contains(er.Error, "Incorrect API key provided") {
+		statusCode = http.StatusUnauthorized
+	}
+
+	return openai.ErrorWrapperWithMessage(er.Error, er.Code, statusCode)
 }

--- a/core/relay/controller/image.go
+++ b/core/relay/controller/image.go
@@ -51,7 +51,7 @@ func GetImageRequestPrice(c *gin.Context, mc *model.ModelConfig) (model.Price, e
 
 	imageCostPrice, ok := GetImageOutputPrice(mc, imageRequest.Size, imageRequest.Quality)
 	if !ok {
-		return model.Price{}, fmt.Errorf("invalid image size: %s", imageRequest.Size)
+		return model.Price{}, fmt.Errorf("invalid image size `%s` or quality `%s`", imageRequest.Size, imageRequest.Quality)
 	}
 
 	return model.Price{


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Improves retry logic in aiproxy by adding delay only when retrying with the same channel for rate limiting issues.

- Refactored retry delay logic in `core/controller/relay-controller.go` to only add delay when using the same channel for rate-limited requests.
- Created a dedicated `relayDelay()` function to centralize the delay implementation.
- Enhanced error handling in `core/relay/adaptor/xai/error.go` to properly map API key errors to HTTP 401 status.
- Improved error message in `core/relay/controller/image.go` to include both size and quality parameters when validation fails.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->