### PR TITLE
debug: add tiktoken encoder loader debug message

### DIFF
--- a/core/common/tiktoken/tiktoken.go
+++ b/core/common/tiktoken/tiktoken.go
@@ -44,10 +44,12 @@ func GetTokenEncoder(model string) *tiktoken.Tiktoken {
 		return tokenEncoder
 	}
 
+	log.Info("loading encoding for model " + model)
+
 	tokenEncoder, err := tiktoken.EncodingForModel(model)
 	if err != nil {
 		if strings.Contains(err.Error(), "no encoding for model") {
-			log.Warnf("no encoding for model %s, using encoder for gpt-3.5-turbo", model)
+			log.Warnf("no encoding for model %s, using default encoder", model)
 			tokenEncoderMap[model] = defaultTokenEncoder
 		} else {
 			log.Errorf("failed to get token encoder for model %s: %v", model, err)
@@ -55,6 +57,8 @@ func GetTokenEncoder(model string) *tiktoken.Tiktoken {
 
 		return defaultTokenEncoder
 	}
+
+	log.Infof("load encoding for model %s success", model)
 
 	tokenEncoderMap[model] = tokenEncoder
 


### PR DESCRIPTION
```
      File: aiproxy
Build ID: 8db07bf12db058faff8ec6c49a5e9364861a4759
Type: samples
Time: 2025-08-09 08:09:10 CST
Duration: 10.13s, Total samples = 995 
Showing nodes accounting for 995, 100% of 995 total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                               358   100% |   github.com/pkoukk/tiktoken-go.bytePairEncode github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:72
       356 35.78% 35.78%        358 35.98%                | github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:33
                                                 2  0.56% |   runtime.asyncPreempt runtime/preempt_amd64.s:8
----------------------------------------------------------+-------------
                                               143   100% |   github.com/pkoukk/tiktoken-go.bytePairEncode github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:72
       143 14.37% 50.15%        143 14.37%                | github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:32
----------------------------------------------------------+-------------
                                                99   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
        99  9.95% 60.10%         99  9.95%                | runtime.memmove runtime/memmove_amd64.s:434
----------------------------------------------------------+-------------
                                                99   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
        99  9.95% 70.05%         99  9.95%                | runtime.memmove runtime/memmove_amd64.s:439
----------------------------------------------------------+-------------
                                                80   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
        80  8.04% 78.09%         80  8.04%                | runtime.memmove runtime/memmove_amd64.s:441
----------------------------------------------------------+-------------
                                                73   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
        73  7.34% 85.43%         73  7.34%                | runtime.memmove runtime/memmove_amd64.s:440
----------------------------------------------------------+-------------
                                                51   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
        51  5.13% 90.55%         51  5.13%                | runtime.memmove runtime/memmove_amd64.s:442
----------------------------------------------------------+-------------
                                                42   100% |   github.com/pkoukk/tiktoken-go.bytePairEncode github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:72
        42  4.22% 94.77%         42  4.22%                | github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:39
----------------------------------------------------------+-------------
                                                29   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
        29  2.91% 97.69%         29  2.91%                | runtime.memmove runtime/memmove_amd64.s:443
----------------------------------------------------------+-------------
                                                 4   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
         4   0.4% 98.09%          4   0.4%                | runtime.memmove runtime/memmove_amd64.s:445
----------------------------------------------------------+-------------
                                                 4   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
         4   0.4% 98.49%          4   0.4%                | runtime.memmove runtime/memmove_amd64.s:448
----------------------------------------------------------+-------------
                                                 3   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
         3   0.3% 98.79%          3   0.3%                | runtime.memmove runtime/memmove_amd64.s:446
----------------------------------------------------------+-------------
                                                 3   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
         3   0.3% 99.10%          3   0.3%                | runtime.memmove runtime/memmove_amd64.s:447
----------------------------------------------------------+-------------
                                                 2   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:33
         2   0.2% 99.30%          2   0.2%                | runtime.asyncPreempt runtime/preempt_amd64.s:8
----------------------------------------------------------+-------------
                                                 2   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
         2   0.2% 99.50%          2   0.2%                | runtime.memmove runtime/memmove_amd64.s:433
----------------------------------------------------------+-------------
                                                 2   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
         2   0.2% 99.70%          2   0.2%                | runtime.memmove runtime/memmove_amd64.s:444
----------------------------------------------------------+-------------
                                                 2   100% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
         2   0.2% 99.90%          2   0.2%                | runtime.memmove runtime/memmove_amd64.s:449
----------------------------------------------------------+-------------
                                                 1   100% |   runtime.findRunnable runtime/proc.go:3689 (inline)
         1   0.1%   100%          1   0.1%                | runtime.(*m).becomeSpinning runtime/proc.go:1016
----------------------------------------------------------+-------------
                                               994   100% |   github.com/gin-gonic/gin.(*Engine).handleHTTPRequest github.com/gin-gonic/gin@v1.10.1/gin.go:644 (inline)
                                               994   100% |   github.com/labring/aiproxy/core/middleware.GinRecoveryHandler github.com/labring/aiproxy/core/middleware/recover.go:77 (inline)
                                               994   100% |   github.com/labring/aiproxy/core/middleware.IPBlock github.com/labring/aiproxy/core/middleware/ipblack.go:20 (inline)
                                               994   100% |   github.com/labring/aiproxy/core/middleware.TokenAuth github.com/labring/aiproxy/core/middleware/auth.go:160 (inline)
                                               994   100% |   github.com/labring/aiproxy/core/middleware.distribute github.com/labring/aiproxy/core/middleware/distributor.go:463 (inline)
                                               994   100% |   main.setupHTTPServer.NewLog.func1 github.com/labring/aiproxy/core/middleware/log.go:30
         0     0%   100%        994 99.90%                | github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185
                                               994   100% |   github.com/labring/aiproxy/core/controller.ChatCompletions.NewDistribute.func1 github.com/labring/aiproxy/core/middleware/distributor.go:317
                                               994   100% |   github.com/labring/aiproxy/core/controller.NewRelay.func1 github.com/labring/aiproxy/core/controller/relay-controller.go:178
                                               994   100% |   github.com/labring/aiproxy/core/middleware.GinRecoveryHandler github.com/labring/aiproxy/core/middleware/recover.go:77
                                               994   100% |   github.com/labring/aiproxy/core/middleware.IPBlock github.com/labring/aiproxy/core/middleware/ipblack.go:20
                                               994   100% |   github.com/labring/aiproxy/core/middleware.TokenAuth github.com/labring/aiproxy/core/middleware/auth.go:160
                                               994   100% |   main.setupHTTPServer.NewLog.func1 github.com/labring/aiproxy/core/middleware/log.go:30
----------------------------------------------------------+-------------
                                               994   100% |   net/http.serverHandler.ServeHTTP net/http/server.go:3301
         0     0%   100%        994 99.90%                | github.com/gin-gonic/gin.(*Engine).ServeHTTP github.com/gin-gonic/gin@v1.10.1/gin.go:600
                                               994   100% |   github.com/gin-gonic/gin.(*Engine).handleHTTPRequest github.com/gin-gonic/gin@v1.10.1/gin.go:644
----------------------------------------------------------+-------------
                                               994   100% |   github.com/gin-gonic/gin.(*Engine).ServeHTTP github.com/gin-gonic/gin@v1.10.1/gin.go:600
         0     0%   100%        994 99.90%                | github.com/gin-gonic/gin.(*Engine).handleHTTPRequest github.com/gin-gonic/gin@v1.10.1/gin.go:644
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185 (inline)
----------------------------------------------------------+-------------
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/controller.ChatCompletions.NewDistribute.func1 github.com/labring/aiproxy/core/middleware/distributor.go:317
                                               994   100% |   github.com/labring/aiproxy/core/middleware.distribute github.com/labring/aiproxy/core/middleware/distributor.go:463
----------------------------------------------------------+-------------
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/controller.NewRelay.func1 github.com/labring/aiproxy/core/controller/relay-controller.go:178
                                               994   100% |   github.com/labring/aiproxy/core/controller.relay github.com/labring/aiproxy/core/controller/relay-controller.go:222
----------------------------------------------------------+-------------
                                               994   100% |   github.com/labring/aiproxy/core/controller.NewRelay.func1 github.com/labring/aiproxy/core/controller/relay-controller.go:178
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/controller.relay github.com/labring/aiproxy/core/controller/relay-controller.go:222
                                               994   100% |   github.com/labring/aiproxy/core/relay/controller.GetChatRequestUsage github.com/labring/aiproxy/core/relay/controller/chat.go:21
----------------------------------------------------------+-------------
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/middleware.GinRecoveryHandler github.com/labring/aiproxy/core/middleware/recover.go:77
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185 (inline)
----------------------------------------------------------+-------------
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/middleware.IPBlock github.com/labring/aiproxy/core/middleware/ipblack.go:20
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185 (inline)
----------------------------------------------------------+-------------
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/middleware.TokenAuth github.com/labring/aiproxy/core/middleware/auth.go:160
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185 (inline)
----------------------------------------------------------+-------------
                                               994   100% |   github.com/labring/aiproxy/core/controller.ChatCompletions.NewDistribute.func1 github.com/labring/aiproxy/core/middleware/distributor.go:317
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/middleware.distribute github.com/labring/aiproxy/core/middleware/distributor.go:463
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185 (inline)
----------------------------------------------------------+-------------
                                               994   100% |   github.com/labring/aiproxy/core/relay/controller.GetChatRequestUsage github.com/labring/aiproxy/core/relay/controller/chat.go:21
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/relay/adaptor/openai.CountTokenMessages github.com/labring/aiproxy/core/relay/adaptor/openai/token.go:44
                                               994   100% |   github.com/labring/aiproxy/core/relay/adaptor/openai.getTokenNum github.com/labring/aiproxy/core/relay/adaptor/openai/token.go:16 (inline)
----------------------------------------------------------+-------------
                                               994   100% |   github.com/labring/aiproxy/core/relay/adaptor/openai.CountTokenMessages github.com/labring/aiproxy/core/relay/adaptor/openai/token.go:44 (inline)
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/relay/adaptor/openai.getTokenNum github.com/labring/aiproxy/core/relay/adaptor/openai/token.go:16
                                               994   100% |   github.com/pkoukk/tiktoken-go.(*Tiktoken).Encode github.com/pkoukk/tiktoken-go@v0.1.7/tiktoken.go:81
----------------------------------------------------------+-------------
                                               994   100% |   github.com/labring/aiproxy/core/controller.relay github.com/labring/aiproxy/core/controller/relay-controller.go:222
         0     0%   100%        994 99.90%                | github.com/labring/aiproxy/core/relay/controller.GetChatRequestUsage github.com/labring/aiproxy/core/relay/controller/chat.go:21
                                               994   100% |   github.com/labring/aiproxy/core/relay/adaptor/openai.CountTokenMessages github.com/labring/aiproxy/core/relay/adaptor/openai/token.go:44
----------------------------------------------------------+-------------
                                               994   100% |   github.com/pkoukk/tiktoken-go.(*Tiktoken).Encode github.com/pkoukk/tiktoken-go@v0.1.7/tiktoken.go:81
         0     0%   100%        994 99.90%                | github.com/pkoukk/tiktoken-go.(*CoreBPE).encodeNative github.com/pkoukk/tiktoken-go@v0.1.7/core_bpe.go:111
                                               994   100% |   github.com/pkoukk/tiktoken-go.bytePairEncode github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:72
----------------------------------------------------------+-------------
                                               994   100% |   github.com/labring/aiproxy/core/relay/adaptor/openai.getTokenNum github.com/labring/aiproxy/core/relay/adaptor/openai/token.go:16
         0     0%   100%        994 99.90%                | github.com/pkoukk/tiktoken-go.(*Tiktoken).Encode github.com/pkoukk/tiktoken-go@v0.1.7/tiktoken.go:81
                                               994   100% |   github.com/pkoukk/tiktoken-go.(*CoreBPE).encodeNative github.com/pkoukk/tiktoken-go@v0.1.7/core_bpe.go:111
----------------------------------------------------------+-------------
                                               994   100% |   github.com/pkoukk/tiktoken-go.(*CoreBPE).encodeNative github.com/pkoukk/tiktoken-go@v0.1.7/core_bpe.go:111
         0     0%   100%        994 99.90%                | github.com/pkoukk/tiktoken-go.bytePairEncode github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:72
                                               451 45.37% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
                                               358 36.02% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:33
                                               143 14.39% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:32
                                                42  4.23% |   github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:39
----------------------------------------------------------+-------------
                                               451   100% |   github.com/pkoukk/tiktoken-go.bytePairEncode github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:72
         0     0%   100%        451 45.33%                | github.com/pkoukk/tiktoken-go.bytePairMerge[go.shape.int] github.com/pkoukk/tiktoken-go@v0.1.7/bpe.go:54
                                                99 21.95% |   runtime.memmove runtime/memmove_amd64.s:434
                                                99 21.95% |   runtime.memmove runtime/memmove_amd64.s:439
                                                80 17.74% |   runtime.memmove runtime/memmove_amd64.s:441
                                                73 16.19% |   runtime.memmove runtime/memmove_amd64.s:440
                                                51 11.31% |   runtime.memmove runtime/memmove_amd64.s:442
                                                29  6.43% |   runtime.memmove runtime/memmove_amd64.s:443
                                                 4  0.89% |   runtime.memmove runtime/memmove_amd64.s:445
                                                 4  0.89% |   runtime.memmove runtime/memmove_amd64.s:448
                                                 3  0.67% |   runtime.memmove runtime/memmove_amd64.s:446
                                                 3  0.67% |   runtime.memmove runtime/memmove_amd64.s:447
                                                 2  0.44% |   runtime.memmove runtime/memmove_amd64.s:433
                                                 2  0.44% |   runtime.memmove runtime/memmove_amd64.s:444
                                                 2  0.44% |   runtime.memmove runtime/memmove_amd64.s:449
----------------------------------------------------------+-------------
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185
         0     0%   100%        994 99.90%                | main.setupHTTPServer.NewLog.func1 github.com/labring/aiproxy/core/middleware/log.go:30
                                               994   100% |   github.com/gin-gonic/gin.(*Context).Next github.com/gin-gonic/gin@v1.10.1/context.go:185
----------------------------------------------------------+-------------
         0     0%   100%        994 99.90%                | net/http.(*conn).serve net/http/server.go:2102
                                               994   100% |   net/http.serverHandler.ServeHTTP net/http/server.go:3301
----------------------------------------------------------+-------------
                                               994   100% |   net/http.(*conn).serve net/http/server.go:2102
         0     0%   100%        994 99.90%                | net/http.serverHandler.ServeHTTP net/http/server.go:3301
                                               994   100% |   github.com/gin-gonic/gin.(*Engine).ServeHTTP github.com/gin-gonic/gin@v1.10.1/gin.go:600
----------------------------------------------------------+-------------
                                                 1   100% |   runtime.schedule runtime/proc.go:4072
         0     0%   100%          1   0.1%                | runtime.findRunnable runtime/proc.go:3689
                                                 1   100% |   runtime.(*m).becomeSpinning runtime/proc.go:1016 (inline)
----------------------------------------------------------+-------------
         0     0%   100%          1   0.1%                | runtime.mcall runtime/asm_amd64.s:459
                                                 1   100% |   runtime.park_m runtime/proc.go:4201
----------------------------------------------------------+-------------
                                                 1   100% |   runtime.mcall runtime/asm_amd64.s:459
         0     0%   100%          1   0.1%                | runtime.park_m runtime/proc.go:4201
                                                 1   100% |   runtime.schedule runtime/proc.go:4072
----------------------------------------------------------+-------------
                                                 1   100% |   runtime.park_m runtime/proc.go:4201
         0     0%   100%          1   0.1%                | runtime.schedule runtime/proc.go:4072
                                                 1   100% |   runtime.findRunnable runtime/proc.go:3689
----------------------------------------------------------+-------------
```