### PR TITLE
调整阿里云百炼对接anthropic接口，原接口只支持qwen3-coder，不支持制定模型

### DIFF
--- a/core/relay/adaptor/ali/adaptor.go
+++ b/core/relay/adaptor/ali/adaptor.go
@@ -113,7 +113,7 @@ func (a *Adaptor) GetRequestURL(
 			URL:    url,
 		}, nil
 	case mode.Anthropic:
-		url, err := url.JoinPath(u, "/api/v2/apps/claude-code-proxy/v1/messages")
+		url, err := url.JoinPath(u, "/apps/anthropic/v1/messages")
 		if err != nil {
 			return adaptor.RequestURL{}, err
 		}


### PR DESCRIPTION
https://help.aliyun.com/zh/model-studio/claude-code
<img width="1527" height="352" alt="image" src="https://github.com/user-attachments/assets/c836e1fa-c18f-4860-bc5d-84322c9ba411" />
