### PR TITLE
fix anthropic streaming content_block_start struct bug

### DIFF
--- a/core/relay/model/claude.go
+++ b/core/relay/model/claude.go
@@ -54,8 +54,8 @@ type ClaudeImageSource struct {
 
 type ClaudeContent struct {
 	Type         string              `json:"type"`
-	Text         string              `json:"text,omitempty"`
-	Thinking     string              `json:"thinking,omitempty"`
+	Text         string              `json:"text"`
+	Thinking     string              `json:"thinking"`
 	Source       *ClaudeImageSource  `json:"source,omitempty"`
 	ID           string              `json:"id,omitempty"`
 	Name         string              `json:"name,omitempty"`


### PR DESCRIPTION
opencode Error message: [
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "content_block",
      "text"
    ],
    "message": "Invalid input: expected string, received undefined"
  }
]


-----
-- it is claude exmple
-----

event: content_block_start
data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}