### PR TITLE
fix(doubao): set reasoning_effort field in doubao reasoning conversion

### DIFF
--- a/core/relay/adaptor/doubao/main_test.go
+++ b/core/relay/adaptor/doubao/main_test.go
@@ -2239,16 +2239,20 @@ func TestAdaptorConvertRequestGeminiReasoning(t *testing.T) {
 		t.Fatalf("failed to unmarshal converted body: %v", err)
 	}
 
+	if openAIReq.ReasoningEffort == nil {
+		t.Fatal("expected reasoning_effort to be set")
+	}
+
+	if *openAIReq.ReasoningEffort != "low" {
+		t.Fatalf("expected reasoning_effort=low, got %s", *openAIReq.ReasoningEffort)
+	}
+
 	if openAIReq.Thinking == nil {
 		t.Fatal("expected thinking to be set")
 	}
 
 	if openAIReq.Thinking.Type != relaymodel.ClaudeThinkingTypeEnabled {
-		t.Fatalf("expected thinking.type enabled, got %s", openAIReq.Thinking.Type)
-	}
-
-	if openAIReq.ReasoningEffort != nil {
-		t.Fatal("expected reasoning_effort to be removed")
+		t.Fatalf("expected thinking.type=enabled, got %s", openAIReq.Thinking.Type)
 	}
 }
 
@@ -2290,12 +2294,20 @@ func TestAdaptorConvertRequestChatReasoning(t *testing.T) {
 		t.Fatalf("failed to unmarshal converted body: %v", err)
 	}
 
+	if openAIReq.ReasoningEffort == nil {
+		t.Fatal("expected reasoning_effort to be set")
+	}
+
+	if *openAIReq.ReasoningEffort != "high" {
+		t.Fatalf("expected reasoning_effort=high, got %s", *openAIReq.ReasoningEffort)
+	}
+
 	if openAIReq.Thinking == nil {
 		t.Fatal("expected thinking to be set")
 	}
 
 	if openAIReq.Thinking.Type != relaymodel.ClaudeThinkingTypeEnabled {
-		t.Fatalf("expected thinking.type enabled, got %s", openAIReq.Thinking.Type)
+		t.Fatalf("expected thinking.type=enabled, got %s", openAIReq.Thinking.Type)
 	}
 }
 
@@ -2337,12 +2349,20 @@ func TestAdaptorConvertRequestChatReasoningDisabled(t *testing.T) {
 		t.Fatalf("failed to unmarshal converted body: %v", err)
 	}
 
+	if openAIReq.ReasoningEffort == nil {
+		t.Fatal("expected reasoning_effort to be set")
+	}
+
+	if *openAIReq.ReasoningEffort != "minimal" {
+		t.Fatalf("expected reasoning_effort=minimal, got %s", *openAIReq.ReasoningEffort)
+	}
+
 	if openAIReq.Thinking == nil {
 		t.Fatal("expected thinking to be set")
 	}
 
 	if openAIReq.Thinking.Type != relaymodel.ClaudeThinkingTypeDisabled {
-		t.Fatalf("expected thinking.type disabled, got %s", openAIReq.Thinking.Type)
+		t.Fatalf("expected thinking.type=disabled, got %s", openAIReq.Thinking.Type)
 	}
 }
 
@@ -2478,15 +2498,19 @@ func TestAdaptorConvertRequestAnthropicReasoning(t *testing.T) {
 		t.Fatalf("failed to unmarshal converted body: %v", err)
 	}
 
+	if openAIReq.ReasoningEffort == nil {
+		t.Fatal("expected reasoning_effort to be set")
+	}
+
+	if *openAIReq.ReasoningEffort != "low" {
+		t.Fatalf("expected reasoning_effort=low, got %s", *openAIReq.ReasoningEffort)
+	}
+
 	if openAIReq.Thinking == nil {
 		t.Fatal("expected thinking to be set")
 	}
 
 	if openAIReq.Thinking.Type != relaymodel.ClaudeThinkingTypeEnabled {
-		t.Fatalf("expected thinking.type enabled, got %s", openAIReq.Thinking.Type)
-	}
-
-	if openAIReq.ReasoningEffort != nil {
-		t.Fatal("expected reasoning_effort to be removed")
+		t.Fatalf("expected thinking.type=enabled, got %s", openAIReq.Thinking.Type)
 	}
 }

--- a/core/relay/utils/reasoning.go
+++ b/core/relay/utils/reasoning.go
@@ -449,14 +449,66 @@ func ApplyReasoningToDoubaoNode(
 	node *ast.Node,
 	reasoning relaymodel.NormalizedReasoning,
 ) error {
-	return applyReasoningToThinkingNode(node, reasoning)
+	if node == nil || !reasoning.Specified {
+		return nil
+	}
+
+	effort := doubaoReasoningEffort(reasoning)
+	if effort == "" {
+		return nil
+	}
+
+	thinkingType := relaymodel.ClaudeThinkingTypeEnabled
+	if reasoning.Disabled || effort == "minimal" {
+		thinkingType = relaymodel.ClaudeThinkingTypeDisabled
+	}
+
+	_, _ = node.Unset("thinking")
+
+	if _, err := node.SetAny("thinking", relaymodel.ClaudeThinking{Type: thinkingType}); err != nil {
+		return err
+	}
+
+	_, err := node.Set("reasoning_effort", ast.NewString(effort))
+	return err
 }
 
 func ApplyReasoningToDoubaoRequest(
 	req *relaymodel.GeneralOpenAIRequest,
 	reasoning relaymodel.NormalizedReasoning,
 ) {
-	applyReasoningToThinkingRequest(req, reasoning)
+	if req == nil || !reasoning.Specified {
+		return
+	}
+
+	effort := doubaoReasoningEffort(reasoning)
+	if effort == "" {
+		return
+	}
+
+	thinkingType := relaymodel.ClaudeThinkingTypeEnabled
+	if reasoning.Disabled || effort == "minimal" {
+		thinkingType = relaymodel.ClaudeThinkingTypeDisabled
+	}
+
+	req.Thinking = &relaymodel.GeneralThinking{Type: thinkingType}
+	req.ReasoningEffort = &effort
+}
+
+func doubaoReasoningEffort(reasoning relaymodel.NormalizedReasoning) string {
+	effort := ReasoningToOpenAIEffort(reasoning)
+	switch effort {
+	case relaymodel.ReasoningEffortNone, relaymodel.ReasoningEffortMinimal:
+		return "minimal"
+	case relaymodel.ReasoningEffortLow:
+		return "low"
+	case relaymodel.ReasoningEffortMedium:
+		return "medium"
+	case relaymodel.ReasoningEffortHigh, relaymodel.ReasoningEffortXHigh:
+		return "high"
+	default:
+		return ""
+	}
 }
 
 func applyReasoningToThinkingNode(

--- a/core/relay/utils/reasoning.go
+++ b/core/relay/utils/reasoning.go
@@ -465,11 +465,15 @@ func ApplyReasoningToDoubaoNode(
 
 	_, _ = node.Unset("thinking")
 
-	if _, err := node.SetAny("thinking", relaymodel.ClaudeThinking{Type: thinkingType}); err != nil {
+	if _, err := node.SetAny(
+		"thinking",
+		relaymodel.ClaudeThinking{Type: thinkingType},
+	); err != nil {
 		return err
 	}
 
 	_, err := node.Set("reasoning_effort", ast.NewString(effort))
+
 	return err
 }
 


### PR DESCRIPTION
## Summary

Previously, `ApplyReasoningToDoubaoNode` and `ApplyReasoningToDoubaoRequest` only set the `thinking` field when applying reasoning config. This PR adds the `reasoning_effort` field, mapped to doubao-specific effort values (`minimal`/`low`/`medium`/`high`), consistent with how other providers handle reasoning effort.

## Changes

- **`core/relay/utils/reasoning.go`**: 
  - `ApplyReasoningToDoubaoNode` now sets `reasoning_effort` in addition to `thinking`
  - `ApplyReasoningToDoubaoRequest` now sets `reasoning_effort` in addition to `thinking`
  - Added `doubaoReasoningEffort()` helper that maps normalized reasoning levels to doubao-specific effort values

- **`core/relay/adaptor/doubao/main_test.go`**: 
  - Updated 4 test cases to verify `reasoning_effort` is correctly set
  - Fixed assertion message formatting (`thinking.type enabled` → `thinking.type=enabled`)