### PR TITLE
fix(doc2x): preserve parsed content and harden result processing

### DIFF
--- a/core/relay/adaptor/doc2x/html2md_test.go
+++ b/core/relay/adaptor/doc2x/html2md_test.go
@@ -1,10 +1,85 @@
 package doc2x_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/labring/aiproxy/core/relay/adaptor/doc2x"
 )
+
+func TestCleanMarkdownNormalizesDoc2XFragments(t *testing.T) {
+	t.Parallel()
+
+	input := `<!-- Meanless: 人工智能生成内容（AIGC）白皮书 -->
+深度神经网络在学习范式 \( {}^{2} \) 和矩阵 \[ x+y \]
+<!-- Media -->
+<!-- figureText: 输入图像。<br>输出结果 -->
+<!-- Footnote -->`
+	result := doc2x.CleanMarkdown(input)
+
+	if !strings.Contains(result, `深度神经网络在学习范式 [^2] 和矩阵 $$ x+y $$`) {
+		t.Fatalf("math delimiters or footnote reference were not normalized: %q", result)
+	}
+	if !strings.Contains(result, "**图内文字**\n\n输入图像。\n输出结果") {
+		t.Fatalf("figure text was lost: %q", result)
+	}
+	for _, marker := range []string{"<!-- Meanless:", "<!-- Media -->", "<!-- figureText:", "<!-- Footnote -->"} {
+		if strings.Contains(result, marker) {
+			t.Fatalf("comment marker %q remains in %q", marker, result)
+		}
+	}
+}
+
+func TestCleanMarkdownNormalizesMathTagsAndTextSubscripts(t *testing.T) {
+	t.Parallel()
+
+	result := doc2x.CleanMarkdown(`$x + y \tag{1}$ and \text{where a_b is defined}`)
+	expected := `$$x + y \qquad \qquad (1)$$ and \text{where a\_b is defined}`
+	if result != expected {
+		t.Fatalf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestCleanMarkdownFormatsFootnoteBlock(t *testing.T) {
+	t.Parallel()
+
+	input := `正文 \( {}^{2} \)
+
+---
+<!-- Footnote -->
+2 脚注说明
+
+https://example.com/reference
+<!-- Footnote -->
+---`
+	result := doc2x.CleanMarkdown(input)
+	expected := "正文 [^2]\n\n[^2]: 脚注说明\n\n    https://example.com/reference"
+	if result != expected {
+		t.Fatalf("expected %q, got %q", expected, result)
+	}
+	if strings.Contains(result, "<!-- Footnote -->") || strings.Contains(result, "\n---\n") {
+		t.Fatalf("footnote markers or separators remain: %q", result)
+	}
+}
+
+func TestCleanMarkdownCollapsesBlankLinesWithoutDroppingText(t *testing.T) {
+	t.Parallel()
+
+	result := doc2x.CleanMarkdown("第一段\n\n\n\n第二段")
+	if result != "第一段\n\n第二段" {
+		t.Fatalf("expected normalized paragraphs, got %q", result)
+	}
+}
+
+func TestHTMLImage2MdPreservesSignedURLQuery(t *testing.T) {
+	t.Parallel()
+
+	input := `<img src="https://img.doc2x.noedgeai.com/page.jpg?x=275&y=216&w=1189&h=678&r=0"/>`
+	expected := `![img](https://img.doc2x.noedgeai.com/page.jpg?x=275&y=216&w=1189&h=678&r=0)`
+	if result := doc2x.HTMLImage2Md(input); result != expected {
+		t.Fatalf("expected %q, got %q", expected, result)
+	}
+}
 
 func TestHTMLTable2Md(t *testing.T) {
 	t.Parallel()

--- a/core/relay/adaptor/doc2x/html2md_test.go
+++ b/core/relay/adaptor/doc2x/html2md_test.go
@@ -20,9 +20,11 @@ func TestCleanMarkdownNormalizesDoc2XFragments(t *testing.T) {
 	if !strings.Contains(result, `深度神经网络在学习范式 [^2] 和矩阵 $$ x+y $$`) {
 		t.Fatalf("math delimiters or footnote reference were not normalized: %q", result)
 	}
+
 	if !strings.Contains(result, "**图内文字**\n\n输入图像。\n输出结果") {
 		t.Fatalf("figure text was lost: %q", result)
 	}
+
 	for _, marker := range []string{"<!-- Meanless:", "<!-- Media -->", "<!-- figureText:", "<!-- Footnote -->"} {
 		if strings.Contains(result, marker) {
 			t.Fatalf("comment marker %q remains in %q", marker, result)
@@ -34,6 +36,7 @@ func TestCleanMarkdownNormalizesMathTagsAndTextSubscripts(t *testing.T) {
 	t.Parallel()
 
 	result := doc2x.CleanMarkdown(`$x + y \tag{1}$ and \text{where a_b is defined}`)
+
 	expected := `$$x + y \qquad \qquad (1)$$ and \text{where a\_b is defined}`
 	if result != expected {
 		t.Fatalf("expected %q, got %q", expected, result)
@@ -53,10 +56,12 @@ https://example.com/reference
 <!-- Footnote -->
 ---`
 	result := doc2x.CleanMarkdown(input)
+
 	expected := "正文 [^2]\n\n[^2]: 脚注说明\n\n    https://example.com/reference"
 	if result != expected {
 		t.Fatalf("expected %q, got %q", expected, result)
 	}
+
 	if strings.Contains(result, "<!-- Footnote -->") || strings.Contains(result, "\n---\n") {
 		t.Fatalf("footnote markers or separators remain: %q", result)
 	}
@@ -75,6 +80,7 @@ func TestHTMLImage2MdPreservesSignedURLQuery(t *testing.T) {
 	t.Parallel()
 
 	input := `<img src="https://img.doc2x.noedgeai.com/page.jpg?x=275&y=216&w=1189&h=678&r=0"/>`
+
 	expected := `![img](https://img.doc2x.noedgeai.com/page.jpg?x=275&y=216&w=1189&h=678&r=0)`
 	if result := doc2x.HTMLImage2Md(input); result != expected {
 		t.Fatalf("expected %q, got %q", expected, result)

--- a/core/relay/adaptor/doc2x/pdf.go
+++ b/core/relay/adaptor/doc2x/pdf.go
@@ -97,6 +97,7 @@ func HandleParsePdfResponse(
 			http.StatusBadRequest,
 		)
 	}
+
 	if response.Data.UID == "" {
 		return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
 			"parse pdf failed: uid is empty",
@@ -125,11 +126,13 @@ func HandleParsePdfResponse(
 					http.StatusBadGateway,
 				)
 			}
+
 			return handleParsePdfResponse(meta, c, status.Result)
 		case StatusResponseDataStatusReady, StatusResponseDataStatusProcessing:
 			if attempt == statusPollMaxAttempts-1 {
 				break
 			}
+
 			select {
 			case <-ctx.Done():
 				return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
@@ -180,12 +183,14 @@ var (
 	textSubscriptRegex       = regexp.MustCompile(`\\text\{([^}]*?)(\b\w+)_(\w+\b)([^}]*?)\}`)
 	simpleFootnoteRefRegex   = regexp.MustCompile(`\$\s*\{\}\^\{(\d+)\}\s*\$`)
 
-	mediaCommentRegex     = regexp.MustCompile(`<!-- Media -->`)
-	footnoteCommentRegex  = regexp.MustCompile(`<!-- Footnote -->`)
-	meanlessCommentRegex  = regexp.MustCompile(`(?s)<!-- Meanless:.*?-->`)
-	figureTextRegex       = regexp.MustCompile(`(?s)<!-- figureText:\s*(.*?)\s*-->`)
-	figureLineBreakRegex  = regexp.MustCompile(`(?i)<br\s*/?>`)
-	footnoteSectionRegex  = regexp.MustCompile(`(?s)(?:^|\n)\s*---\s*<!-- Footnote -->\s*(.*?)\s*<!-- Footnote -->\s*---\s*(?:\n|$)`)
+	mediaCommentRegex    = regexp.MustCompile(`<!-- Media -->`)
+	footnoteCommentRegex = regexp.MustCompile(`<!-- Footnote -->`)
+	meanlessCommentRegex = regexp.MustCompile(`(?s)<!-- Meanless:.*?-->`)
+	figureTextRegex      = regexp.MustCompile(`(?s)<!-- figureText:\s*(.*?)\s*-->`)
+	figureLineBreakRegex = regexp.MustCompile(`(?i)<br\s*/?>`)
+	footnoteSectionRegex = regexp.MustCompile(
+		`(?s)(?:^|\n)\s*---\s*<!-- Footnote -->\s*(.*?)\s*<!-- Footnote -->\s*---\s*(?:\n|$)`,
+	)
 	footnoteBlockRegex    = regexp.MustCompile(`(?s)<!-- Footnote -->\s*(.*?)\s*<!-- Footnote -->`)
 	plainFootnoteNumRegex = regexp.MustCompile(`^(\d+)\s+`)
 	mathFootnoteNumRegex  = regexp.MustCompile(`^\\\(\s*\{\}\^\{(\d+)\}\s*\\\)\s*`)
@@ -227,6 +232,7 @@ func CleanMarkdown(content string) string {
 	content = footnoteCommentRegex.ReplaceAllString(content, "")
 	content = meanlessCommentRegex.ReplaceAllString(content, "")
 	content = excessBlankLinesRegex.ReplaceAllString(content, "\n\n")
+
 	return strings.TrimSpace(content)
 }
 
@@ -256,6 +262,7 @@ func formatFootnote(body string) string {
 			lines[i] = "    " + lines[i]
 		}
 	}
+
 	return "\n\n[^" + number + "]: " + strings.Join(lines, "\n") + "\n\n"
 }
 
@@ -507,8 +514,10 @@ func imageURL2MdBase64(ctx context.Context, m *meta.Meta, url, altText string) (
 		if !commonimage.IsImageURL(detectedMime) {
 			return "", fmt.Errorf("downloaded content is not an image: %s", detectedMime)
 		}
+
 		mime = detectedMime
 	}
+
 	if mime == "" {
 		mime = inferMimeType(url)
 	}
@@ -646,6 +655,7 @@ func GetStatus(ctx context.Context, meta *meta.Meta, uid string) (*StatusRespons
 	if !isSuccessfulResponseCode(response.Code) {
 		return nil, errors.New("get status failed: " + response.Msg)
 	}
+
 	if response.Data == nil {
 		return nil, errors.New("get status failed: response data is empty")
 	}

--- a/core/relay/adaptor/doc2x/pdf.go
+++ b/core/relay/adaptor/doc2x/pdf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/gin-gonic/gin"
 	"github.com/labring/aiproxy/core/common"
+	commonimage "github.com/labring/aiproxy/core/common/image"
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/relay/adaptor"
 	"github.com/labring/aiproxy/core/relay/meta"
@@ -59,6 +60,20 @@ type ParsePdfResponseData struct {
 	UID string `json:"uid"`
 }
 
+const (
+	StatusResponseDataStatusSuccess    = "success"
+	StatusResponseDataStatusReady      = "ready"
+	StatusResponseDataStatusProcessing = "processing"
+	StatusResponseDataStatusFailed     = "failed"
+	statusPollMaxAttempts              = 600
+)
+
+var statusPollInterval = time.Second
+
+func isSuccessfulResponseCode(code string) bool {
+	return code == "success" || code == "ok"
+}
+
 func HandleParsePdfResponse(
 	meta *meta.Meta,
 	c *gin.Context,
@@ -75,16 +90,24 @@ func HandleParsePdfResponse(
 		)
 	}
 
-	if response.Code != "success" {
+	if !isSuccessfulResponseCode(response.Code) {
 		return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
 			"parse pdf failed: "+response.Msg,
 			"parse_pdf_failed",
 			http.StatusBadRequest,
 		)
 	}
+	if response.Data.UID == "" {
+		return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
+			"parse pdf failed: uid is empty",
+			"parse_pdf_failed",
+			http.StatusBadGateway,
+		)
+	}
 
-	for {
-		status, err := GetStatus(context.Background(), meta, response.Data.UID)
+	ctx := c.Request.Context()
+	for attempt := range statusPollMaxAttempts {
+		status, err := GetStatus(ctx, meta, response.Data.UID)
 		if err != nil {
 			return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
 				"get status failed: "+err.Error(),
@@ -95,17 +118,47 @@ func HandleParsePdfResponse(
 
 		switch status.Status {
 		case StatusResponseDataStatusSuccess:
+			if status.Result == nil {
+				return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
+					"parse pdf failed: result is empty",
+					"parse_pdf_failed",
+					http.StatusBadGateway,
+				)
+			}
 			return handleParsePdfResponse(meta, c, status.Result)
-		case StatusResponseDataStatusProcessing:
-			time.Sleep(1 * time.Second)
+		case StatusResponseDataStatusReady, StatusResponseDataStatusProcessing:
+			if attempt == statusPollMaxAttempts-1 {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
+					"get status canceled: "+ctx.Err().Error(),
+					"get_status_canceled",
+					http.StatusRequestTimeout,
+				)
+			case <-time.After(statusPollInterval):
+			}
 		case StatusResponseDataStatusFailed:
 			return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
 				"parse pdf failed: "+status.Detail,
 				"parse_pdf_failed",
 				http.StatusBadRequest,
 			)
+		default:
+			return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
+				"get status failed: unknown status "+status.Status,
+				"get_status_failed",
+				http.StatusBadGateway,
+			)
 		}
 	}
+
+	return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIErrorWithMessage(
+		"get status failed: process timeout",
+		"get_status_timeout",
+		http.StatusGatewayTimeout,
+	)
 }
 
 // Start of Selection
@@ -121,9 +174,90 @@ var (
 	htmlImageRegex = regexp.MustCompile(`<img\s+src="([^"]+)"(?:\s*\?[^>]*)?(?:\s*\/>|>)`)
 	imageRegex     = regexp.MustCompile(`!\[(.*?)\]\((http[^)]+)\)`)
 
-	mediaCommentRegex    = regexp.MustCompile(`<!-- Media -->`)
-	footnoteCommentRegex = regexp.MustCompile(`<!-- Footnote -->`)
+	inlineMathDelimiterRegex = regexp.MustCompile(`\\[\(\)]`)
+	blockMathDelimiterRegex  = regexp.MustCompile(`\\[\[\]]`)
+	mathTagRegex             = regexp.MustCompile(`\$(.+?)\s+\\tag\{(.+?)\}\$`)
+	textSubscriptRegex       = regexp.MustCompile(`\\text\{([^}]*?)(\b\w+)_(\w+\b)([^}]*?)\}`)
+	simpleFootnoteRefRegex   = regexp.MustCompile(`\$\s*\{\}\^\{(\d+)\}\s*\$`)
+
+	mediaCommentRegex     = regexp.MustCompile(`<!-- Media -->`)
+	footnoteCommentRegex  = regexp.MustCompile(`<!-- Footnote -->`)
+	meanlessCommentRegex  = regexp.MustCompile(`(?s)<!-- Meanless:.*?-->`)
+	figureTextRegex       = regexp.MustCompile(`(?s)<!-- figureText:\s*(.*?)\s*-->`)
+	figureLineBreakRegex  = regexp.MustCompile(`(?i)<br\s*/?>`)
+	footnoteSectionRegex  = regexp.MustCompile(`(?s)(?:^|\n)\s*---\s*<!-- Footnote -->\s*(.*?)\s*<!-- Footnote -->\s*---\s*(?:\n|$)`)
+	footnoteBlockRegex    = regexp.MustCompile(`(?s)<!-- Footnote -->\s*(.*?)\s*<!-- Footnote -->`)
+	plainFootnoteNumRegex = regexp.MustCompile(`^(\d+)\s+`)
+	mathFootnoteNumRegex  = regexp.MustCompile(`^\\\(\s*\{\}\^\{(\d+)\}\s*\\\)\s*`)
+	excessBlankLinesRegex = regexp.MustCompile(`\n[ \t]*\n(?:[ \t]*\n)+`)
 )
+
+// CleanMarkdown applies the text-only normalization required by Doc2X's
+// Markdown output. Image downloads and HTML table conversion remain separate
+// operations because they need request context and network access respectively.
+func CleanMarkdown(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = footnoteSectionRegex.ReplaceAllStringFunc(content, func(match string) string {
+		parts := footnoteSectionRegex.FindStringSubmatch(match)
+		return formatFootnote(parts[1])
+	})
+	content = footnoteBlockRegex.ReplaceAllStringFunc(content, func(match string) string {
+		parts := footnoteBlockRegex.FindStringSubmatch(match)
+		return formatFootnote(parts[1])
+	})
+	content = figureTextRegex.ReplaceAllStringFunc(content, func(match string) string {
+		parts := figureTextRegex.FindStringSubmatch(match)
+		figureText := figureLineBreakRegex.ReplaceAllString(parts[1], "\n")
+		return "\n\n**图内文字**\n\n" + strings.TrimSpace(figureText) + "\n\n"
+	})
+	content = inlineMathDelimiterRegex.ReplaceAllString(content, "$")
+	content = blockMathDelimiterRegex.ReplaceAllStringFunc(content, func(string) string {
+		return "$$"
+	})
+	content = mathTagRegex.ReplaceAllStringFunc(content, func(match string) string {
+		parts := mathTagRegex.FindStringSubmatch(match)
+		return "$$" + parts[1] + " \\qquad \\qquad (" + parts[2] + ")$$"
+	})
+	content = textSubscriptRegex.ReplaceAllStringFunc(content, func(match string) string {
+		parts := textSubscriptRegex.FindStringSubmatch(match)
+		return "\\text{" + parts[1] + parts[2] + "\\_" + parts[3] + parts[4] + "}"
+	})
+	content = simpleFootnoteRefRegex.ReplaceAllString(content, "[^$1]")
+	content = mediaCommentRegex.ReplaceAllString(content, "")
+	content = footnoteCommentRegex.ReplaceAllString(content, "")
+	content = meanlessCommentRegex.ReplaceAllString(content, "")
+	content = excessBlankLinesRegex.ReplaceAllString(content, "\n\n")
+	return strings.TrimSpace(content)
+}
+
+func formatFootnote(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+
+	var number string
+	if parts := plainFootnoteNumRegex.FindStringSubmatch(body); len(parts) > 1 {
+		number = parts[1]
+		body = plainFootnoteNumRegex.ReplaceAllString(body, "")
+	} else if parts := mathFootnoteNumRegex.FindStringSubmatch(body); len(parts) > 1 {
+		number = parts[1]
+		body = mathFootnoteNumRegex.ReplaceAllString(body, "")
+	}
+
+	body = strings.TrimSpace(body)
+	if number == "" {
+		return "\n\n" + body + "\n\n"
+	}
+
+	lines := strings.Split(body, "\n")
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) != "" {
+			lines[i] = "    " + lines[i]
+		}
+	}
+	return "\n\n[^" + number + "]: " + strings.Join(lines, "\n") + "\n\n"
+}
 
 func HTMLTable2Md(content string) string {
 	return tableRegex.ReplaceAllStringFunc(content, func(htmlTable string) string {
@@ -232,6 +366,7 @@ func InlineMdImage(ctx context.Context, m *meta.Meta, text string) string {
 		resultText strings.Builder
 		wg         sync.WaitGroup
 		mutex      sync.Mutex
+		slots      = make(chan struct{}, 8)
 	)
 
 	type imageInfo struct {
@@ -263,6 +398,15 @@ func InlineMdImage(ctx context.Context, m *meta.Meta, text string) string {
 			defer wg.Done()
 
 			info := &imageInfos[index]
+			select {
+			case slots <- struct{}{}:
+				defer func() { <-slots }()
+			case <-ctx.Done():
+				mutex.Lock()
+				info.replacement = text[info.startPos:info.endPos]
+				mutex.Unlock()
+				return
+			}
 
 			replacement, err := imageURL2MdBase64(ctx, m, info.url, info.altText)
 			if err != nil {
@@ -352,12 +496,19 @@ func imageURL2MdBase64(ctx context.Context, m *meta.Meta, url, altText string) (
 
 	defer resp.Body.Close()
 
-	data, err := common.GetResponseBody(resp)
+	data, err := common.GetResponseBodyLimit(resp, commonimage.MaxImageSize)
 	if err != nil {
 		return "", fmt.Errorf("failed to read image data: %w", err)
 	}
 
-	mime := resp.Header.Get("Content-Type")
+	mime := commonimage.TrimImageContentType(resp.Header.Get("Content-Type"))
+	if !commonimage.IsImageURL(mime) {
+		detectedMime := http.DetectContentType(data)
+		if !commonimage.IsImageURL(detectedMime) {
+			return "", fmt.Errorf("downloaded content is not an image: %s", detectedMime)
+		}
+		mime = detectedMime
+	}
 	if mime == "" {
 		mime = inferMimeType(url)
 	}
@@ -389,13 +540,15 @@ func inferMimeType(u string) string {
 }
 
 func handleConvertPdfToMd(ctx context.Context, m *meta.Meta, str string) string {
-	result := InlineMdImage(ctx, m, str)
+	result := CleanMarkdown(str)
+	result = InlineMdImage(ctx, m, result)
 	result = HTMLTable2Md(result)
 
-	result = mediaCommentRegex.ReplaceAllString(result, "")
-	result = footnoteCommentRegex.ReplaceAllString(result, "")
-
 	return result
+}
+
+func joinMarkdownPages(pages []string) string {
+	return strings.Join(pages, "\n\n")
 }
 
 func handleParsePdfResponse(
@@ -425,11 +578,8 @@ func handleParsePdfResponse(
 		})
 	default:
 		builder := strings.Builder{}
-		builder.Grow(totalLength)
-
-		for _, md := range mds {
-			builder.WriteString(md)
-		}
+		builder.Grow(totalLength + max(0, len(mds)-1)*2)
+		builder.WriteString(joinMarkdownPages(mds))
 
 		result := handleConvertPdfToMd(c.Request.Context(), meta, builder.String())
 		c.JSON(http.StatusOK, relaymodel.ParsePdfResponse{
@@ -449,12 +599,6 @@ type StatusResponse struct {
 	Msg  string              `json:"msg"`
 	Data *StatusResponseData `json:"data"`
 }
-
-const (
-	StatusResponseDataStatusSuccess    = "success"
-	StatusResponseDataStatusProcessing = "processing"
-	StatusResponseDataStatusFailed     = "failed"
-)
 
 type StatusResponseData struct {
 	Progress int                       `json:"progress"`
@@ -499,8 +643,11 @@ func GetStatus(ctx context.Context, meta *meta.Meta, uid string) (*StatusRespons
 		return nil, err
 	}
 
-	if response.Code != "success" {
+	if !isSuccessfulResponseCode(response.Code) {
 		return nil, errors.New("get status failed: " + response.Msg)
+	}
+	if response.Data == nil {
+		return nil, errors.New("get status failed: response data is empty")
 	}
 
 	return response.Data, nil

--- a/core/relay/adaptor/doc2x/pdf_internal_test.go
+++ b/core/relay/adaptor/doc2x/pdf_internal_test.go
@@ -20,6 +20,7 @@ func TestIsSuccessfulResponseCode(t *testing.T) {
 			t.Errorf("expected %q to be accepted", code)
 		}
 	}
+
 	if isSuccessfulResponseCode("failed") {
 		t.Fatal("failed response code was accepted")
 	}
@@ -29,6 +30,7 @@ func TestJoinMarkdownPagesPreservesPageBoundary(t *testing.T) {
 	t.Parallel()
 
 	pages := []string{"第一张页面", "第二张页面"}
+
 	result := joinMarkdownPages(pages)
 	if result != "第一张页面\n\n第二张页面" {
 		t.Fatalf("expected explicit page boundary, got %q", result)
@@ -41,35 +43,46 @@ func TestHandleParsePdfResponsePollsReadyUntilSuccess(t *testing.T) {
 	t.Cleanup(func() { statusPollInterval = oldInterval })
 
 	var calls int
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
+
 		w.Header().Set("Content-Type", "application/json")
+
 		if calls == 1 {
 			_, _ = io.WriteString(w, `{"code":"success","data":{"status":"ready","progress":1}}`)
 			return
 		}
-		_, _ = io.WriteString(w, `{"code":"success","data":{"status":"success","result":{"pages":[{"md":"正文"}]}}}`)
+
+		_, _ = io.WriteString(
+			w,
+			`{"code":"success","data":{"status":"success","result":{"pages":[{"md":"正文"}]}}}`,
+		)
 	}))
 	t.Cleanup(server.Close)
 
 	gin.SetMode(gin.TestMode)
+
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
-	ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+	ctx.Request = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", nil)
 
 	m := &meta.Meta{
 		Channel:        meta.ChannelMeta{BaseURL: server.URL},
 		RequestTimeout: time.Second,
 	}
+
 	response := &http.Response{
 		Body: io.NopCloser(strings.NewReader(`{"code":"success","data":{"uid":"test-uid"}}`)),
 	}
 	if _, err := HandleParsePdfResponse(m, ctx, response); err != nil {
 		t.Fatalf("expected ready status to continue polling: %v", err)
 	}
+
 	if calls != 2 {
 		t.Fatalf("expected two status requests, got %d", calls)
 	}
+
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected successful JSON response, got %d", recorder.Code)
 	}

--- a/core/relay/adaptor/doc2x/pdf_internal_test.go
+++ b/core/relay/adaptor/doc2x/pdf_internal_test.go
@@ -1,0 +1,76 @@
+package doc2x
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/labring/aiproxy/core/relay/meta"
+)
+
+func TestIsSuccessfulResponseCode(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []string{"success", "ok"} {
+		if !isSuccessfulResponseCode(code) {
+			t.Errorf("expected %q to be accepted", code)
+		}
+	}
+	if isSuccessfulResponseCode("failed") {
+		t.Fatal("failed response code was accepted")
+	}
+}
+
+func TestJoinMarkdownPagesPreservesPageBoundary(t *testing.T) {
+	t.Parallel()
+
+	pages := []string{"第一张页面", "第二张页面"}
+	result := joinMarkdownPages(pages)
+	if result != "第一张页面\n\n第二张页面" {
+		t.Fatalf("expected explicit page boundary, got %q", result)
+	}
+}
+
+func TestHandleParsePdfResponsePollsReadyUntilSuccess(t *testing.T) {
+	oldInterval := statusPollInterval
+	statusPollInterval = 0
+	t.Cleanup(func() { statusPollInterval = oldInterval })
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			_, _ = io.WriteString(w, `{"code":"success","data":{"status":"ready","progress":1}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"code":"success","data":{"status":"success","result":{"pages":[{"md":"正文"}]}}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	m := &meta.Meta{
+		Channel:        meta.ChannelMeta{BaseURL: server.URL},
+		RequestTimeout: time.Second,
+	}
+	response := &http.Response{
+		Body: io.NopCloser(strings.NewReader(`{"code":"success","data":{"uid":"test-uid"}}`)),
+	}
+	if _, err := HandleParsePdfResponse(m, ctx, response); err != nil {
+		t.Fatalf("expected ready status to continue polling: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected two status requests, got %d", calls)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected successful JSON response, got %d", recorder.Code)
+	}
+}


### PR DESCRIPTION
- preserve figure OCR text and normalize footnotes
- normalize formulas, page boundaries, and excess whitespace
- limit image downloads and validate image MIME types
- support ready status, polling timeout, and request cancellation
- add regression tests for content preservation and polling