### PR TITLE
ci: run tests and lint in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  golangci-lint-aiproxy:
-    name: Lint AI Proxy
+  test-aiproxy:
+    name: Test AI Proxy
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -38,7 +38,19 @@ jobs:
       - name: Go test
         working-directory: core
         run: |
-          go test -v -timeout 30s -count=1 ./...
+          go test -v -timeout 60s -count=1 ./...
+
+  golangci-lint-aiproxy:
+    name: Lint AI Proxy
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "core/go.mod"
 
       - name: Run Linter
         uses: golangci/golangci-lint-action@v9
@@ -65,8 +77,8 @@ jobs:
             exit 1
           fi
 
-  golangci-lint-mcpservers:
-    name: Lint MCP Servers
+  test-mcpservers:
+    name: Test MCP Servers
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -80,7 +92,19 @@ jobs:
       - name: Go test
         working-directory: mcp-servers
         run: |
-          go test -v -timeout 30s -count=1 ./...
+          go test -v -timeout 60s -count=1 ./...
+
+  golangci-lint-mcpservers:
+    name: Lint MCP Servers
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "mcp-servers/go.mod"
 
       - name: Run Linter
         uses: golangci/golangci-lint-action@v9


### PR DESCRIPTION
## Summary

- split AI Proxy tests and lint into independent jobs
- split MCP Servers tests and lint into independent jobs
- increase Go test timeouts from 30 seconds to 60 seconds

## Verification

- `actionlint .github/workflows/ci.yml`
- `git diff --check`