### PR TITLE
ci: support Aliyun ACR image pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,8 @@ jobs:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/${{ matrix.arch }}
+          provenance: false
+          sbom: false
           outputs: type=image,"name=${{ env.GHCR_REPO }}${{ env.DOCKERHUB_REPO && format(',{0}', env.DOCKERHUB_REPO) }}${{ env.ALIYUN_REPO && format(',{0}', env.ALIYUN_REPO) }}",name-canonical=true,push-by-digest=${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }},push=${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
 
       - name: Export digest
@@ -372,5 +374,7 @@ jobs:
           file: ./core/deploy/Kubefile
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary

- disable provenance attestations for application image builds
- disable SBOM attestations for application and Sealos image builds
- avoid OCI empty-config manifests unsupported by Aliyun ACR

## Verification

- Release workflow completed successfully: https://github.com/zijiren233/aiproxy/actions/runs/32381557269
- verified Buildx receives `--attest type=provenance,disabled=true`
- verified Buildx receives `--attest type=sbom,disabled=true`

Aliyun credentials are not configured in the fork, so the verification run covered Buildx compatibility, architecture image pushes, multi-architecture manifest creation, and Sealos image builds through GHCR.