### PR TITLE
Fix repeated daily quota resets

### DIFF
--- a/core/model/token.go
+++ b/core/model/token.go
@@ -137,13 +137,17 @@ func (t *Token) NeedsPeriodReset() (bool, error) {
 		// Check if we've passed 7 days since last reset
 		return now.Sub(baseTime) >= 7*24*time.Hour, nil
 	case PeriodTypeDaily:
-		// Check if we've crossed to a new day since last reset
-		baseDate := baseTime.Truncate(24 * time.Hour)
-		currentDate := now.Truncate(24 * time.Hour)
+		// Daily quotas use UTC calendar days, not rolling 24-hour windows.
+		baseDate := utcDayStart(baseTime)
+		currentDate := utcDayStart(now)
 		return currentDate.After(baseDate), nil
 	default:
 		return false, fmt.Errorf("unknown period type: %s", t.PeriodType)
 	}
+}
+
+func utcDayStart(t time.Time) time.Time {
+	return t.UTC().Truncate(24 * time.Hour)
 }
 
 const (
@@ -924,9 +928,9 @@ func UpdateTokenUsedAmount(id int, amount float64, requestCount int) (err error)
 	return HandleUpdateResult(result, ErrTokenNotFound)
 }
 
-// calculateNextPeriodStartTime calculates the next period start time based on the last update time and period type
-// This finds the most recent period boundary by incrementing from lastUpdateTime until we reach the current time
-// This maintains period continuity - e.g., if reset was on Jan 15, next periods are Feb 15, Mar 15, etc.
+// calculateNextPeriodStartTime finds the current period boundary. Daily quotas
+// align to UTC midnight; weekly and monthly quotas retain their original
+// cadence from lastUpdateTime.
 func calculateNextPeriodStartTime(lastUpdateTime time.Time, periodType EmptyNullString) time.Time {
 	if lastUpdateTime.IsZero() {
 		// If never initialized, return current time
@@ -980,17 +984,12 @@ func calculateNextPeriodStartTime(lastUpdateTime time.Time, periodType EmptyNull
 		return lastUpdateTime.Add(time.Duration(weeksPassed*7*24) * time.Hour)
 
 	case PeriodTypeDaily:
-		// Calculate how many complete days have passed since lastUpdateTime
-		daysSinceLastUpdate := int(now.Sub(lastUpdateTime).Hours() / 24)
-
-		if daysSinceLastUpdate == 0 {
-			// Still in the same day period, no reset needed
+		currentDayStart := utcDayStart(now)
+		if !utcDayStart(lastUpdateTime).Before(currentDayStart) {
 			return lastUpdateTime
 		}
 
-		// Return the start of the most recent day period
-		// This is lastUpdateTime + (daysPassed * 1 day)
-		return lastUpdateTime.Add(time.Duration(daysSinceLastUpdate*24) * time.Hour)
+		return currentDayStart
 
 	default:
 		// Fallback to current time for unknown period types

--- a/core/model/token_period_test.go
+++ b/core/model/token_period_test.go
@@ -1,0 +1,43 @@
+//nolint:testpackage
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetDailyTokenPeriodAdvancesOnceAtUTCDayBoundary(t *testing.T) {
+	withTestModelCacheDB(t, func() {
+		todayStart := time.Now().UTC().Truncate(24 * time.Hour)
+		token := &Token{
+			Name:                   "daily-quota",
+			PeriodQuota:            20,
+			PeriodType:             PeriodTypeDaily,
+			PeriodLastUpdateTime:   todayStart.Add(-time.Nanosecond),
+			PeriodLastUpdateAmount: 10,
+			UsedAmount:             100,
+			Status:                 TokenStatusEnabled,
+		}
+		require.NoError(t, DB.Create(token).Error)
+
+		require.NoError(t, ResetTokenPeriodUsage(token.ID))
+
+		afterFirstReset, err := GetTokenByID(token.ID)
+		require.NoError(t, err)
+		require.Equal(t, todayStart, afterFirstReset.PeriodLastUpdateTime.UTC())
+		require.Equal(t, 100.0, afterFirstReset.PeriodLastUpdateAmount)
+
+		require.NoError(
+			t,
+			DB.Model(&Token{}).Where("id = ?", token.ID).Update("used_amount", 105).Error,
+		)
+		require.NoError(t, ResetTokenPeriodUsage(token.ID))
+
+		afterSecondReset, err := GetTokenByID(token.ID)
+		require.NoError(t, err)
+		require.Equal(t, todayStart, afterSecondReset.PeriodLastUpdateTime.UTC())
+		require.Equal(t, 100.0, afterSecondReset.PeriodLastUpdateAmount)
+	})
+}


### PR DESCRIPTION
## Summary

- align daily quota reset detection and mutation to UTC calendar-day boundaries
- prevent repeated usage-baseline resets after UTC midnight but before a rolling 24-hour interval has elapsed
- add a regression test covering the first reset and a second same-day reset attempt

## Root cause

`NeedsPeriodReset` detected a UTC date rollover, while `calculateNextPeriodStartTime` required a complete 24-hour interval. During that gap, each request could refresh `period_last_update_amount` without advancing `period_last_update_time`, allowing daily quota usage to be repeatedly reset.

## Tests

- `go test ./core/model -run TestResetDailyTokenPeriodAdvancesOnceAtUTCDayBoundary -count=20`
- `go test -race ./core/model -run TestResetDailyTokenPeriodAdvancesOnceAtUTCDayBoundary -count=5`
- `go test ./core/model -skip "(Postgres|Redis)" -count=1`