### PR TITLE
fix: honor channel proxies across auxiliary requests

### DIFF
--- a/core/controller/channel.go
+++ b/core/controller/channel.go
@@ -16,6 +16,7 @@ import (
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/monitor"
 	"github.com/labring/aiproxy/core/relay/adaptors"
+	relayutils "github.com/labring/aiproxy/core/relay/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -393,6 +394,12 @@ func (r *UpdateChannelRequest) Apply(current *model.Channel) (*model.Channel, er
 		next.BalanceThreshold = *r.BalanceThreshold
 	}
 
+	if r.ProxyURL != nil {
+		if err := relayutils.ValidateProxyURL(*r.ProxyURL); err != nil {
+			return nil, err
+		}
+	}
+
 	if _, err := (&AddChannelRequest{Type: next.Type, Name: next.Name, Key: next.Key}).ToChannel(); err != nil {
 		return nil, err
 	}
@@ -401,6 +408,10 @@ func (r *UpdateChannelRequest) Apply(current *model.Channel) (*model.Channel, er
 }
 
 func (r *AddChannelRequest) ToChannel() (*model.Channel, error) {
+	if err := relayutils.ValidateProxyURL(r.ProxyURL); err != nil {
+		return nil, err
+	}
+
 	a, ok := adaptors.GetAdaptor(r.Type)
 	if !ok {
 		return nil, fmt.Errorf("invalid channel type: %d", r.Type)

--- a/core/controller/channel_test.go
+++ b/core/controller/channel_test.go
@@ -114,6 +114,39 @@ func TestChannelFilterOptionalValues(t *testing.T) {
 	}
 }
 
+func TestChannelProxyOptionalUpdates(t *testing.T) {
+	t.Parallel()
+
+	current := &model.Channel{
+		Type: model.ChannelTypeOpenAI, Key: "test-key", ProxyURL: "legacy-invalid-proxy",
+	}
+	for _, tt := range []struct {
+		body string
+		want string
+	}{
+		{body: `{}`, want: current.ProxyURL},
+		{body: `{"proxy_url":null}`, want: current.ProxyURL},
+		{body: `{"proxy_url":""}`, want: ""},
+		{body: `{"proxy_url":"socks5://proxy.example:1080"}`, want: "socks5://proxy.example:1080"},
+	} {
+		var request UpdateChannelRequest
+		require.NoError(t, sonic.UnmarshalString(tt.body, &request))
+		updated, err := request.Apply(current)
+		require.NoError(t, err)
+		require.Equal(t, tt.want, updated.ProxyURL)
+		require.Equal(t, "legacy-invalid-proxy", current.ProxyURL)
+	}
+
+	for _, proxyURL := range []string{"http://", "proxy.example:8080", "socks5://proxy.example:65536"} {
+		_, err := (&AddChannelRequest{
+			Type: model.ChannelTypeOpenAI, Key: "test-key", ProxyURL: proxyURL,
+		}).ToChannel()
+		require.Error(t, err)
+		_, err = (&UpdateChannelRequest{ProxyURL: &proxyURL}).Apply(current)
+		require.Error(t, err)
+	}
+}
+
 func TestChannelFiltersRejectInvalidBooleans(t *testing.T) {
 	t.Parallel()
 

--- a/core/internal/testutil/proxy.go
+++ b/core/internal/testutil/proxy.go
@@ -1,0 +1,107 @@
+package testutil
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type ProxyRequest struct {
+	Method        string
+	Host          string
+	Authorization string
+}
+
+// NewHTTPProxy routes all requests to a local upstream, including CONNECT tunnels.
+func NewHTTPProxy(
+	tb testing.TB,
+	upstream *httptest.Server,
+	useTLS bool,
+) (*httptest.Server, <-chan ProxyRequest) {
+	tb.Helper()
+
+	target, err := url.Parse(upstream.URL)
+	require.NoError(tb, err)
+
+	requests := make(chan ProxyRequest, 32)
+	forward := &httputil.ReverseProxy{
+		Transport: upstream.Client().Transport,
+		Rewrite: func(req *httputil.ProxyRequest) {
+			req.SetURL(target)
+			req.Out.Header.Del("Proxy-Authorization")
+		},
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests <- ProxyRequest{
+			Method: req.Method, Host: req.Host,
+			Authorization: req.Header.Get("Proxy-Authorization"),
+		}
+
+		if req.Method != http.MethodConnect {
+			forward.ServeHTTP(w, req)
+			return
+		}
+
+		dialer := net.Dialer{Timeout: time.Second}
+
+		remote, err := dialer.DialContext(req.Context(), "tcp", target.Host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer remote.Close()
+
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijacking unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		client, buffered, err := hijacker.Hijack()
+		if err != nil {
+			return
+		}
+		defer client.Close()
+
+		if _, err := buffered.WriteString(
+			"HTTP/1.1 200 Connection Established\r\n\r\n",
+		); err != nil {
+			return
+		}
+
+		if err := buffered.Flush(); err != nil {
+			return
+		}
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+
+			_, _ = io.Copy(remote, buffered)
+			_ = remote.Close()
+		}()
+
+		_, _ = io.Copy(client, remote)
+		_ = client.Close()
+
+		<-done
+	})
+
+	var server *httptest.Server
+	if useTLS {
+		server = httptest.NewTLSServer(handler)
+	} else {
+		server = httptest.NewServer(handler)
+	}
+
+	tb.Cleanup(server.Close)
+
+	return server, requests
+}

--- a/core/relay/adaptor/ali/adaptor_test.go
+++ b/core/relay/adaptor/ali/adaptor_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/labring/aiproxy/core/internal/testutil"
 	coremodel "github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/relay/adaptor"
 	"github.com/labring/aiproxy/core/relay/meta"
@@ -2663,7 +2664,13 @@ func TestAsyncTaskUsesBaseURL(t *testing.T) {
 	}))
 	defer server.Close()
 
-	response, err := asyncTask(context.Background(), server.URL+"/custom", "task-123", "test-key")
+	proxy, _ := testutil.NewHTTPProxy(t, server, true)
+	m := meta.NewMeta(&coremodel.Channel{
+		BaseURL: "http://upstream.invalid/custom", Key: "test-key",
+		ProxyURL: proxy.URL, SkipTLSVerify: true,
+	}, mode.ImagesGenerations, "wanx", coremodel.ModelConfig{})
+
+	response, err := asyncTask(t.Context(), m, "task-123")
 	if err != nil {
 		t.Fatalf("asyncTask returned error: %v", err)
 	}

--- a/core/relay/adaptor/ali/image.go
+++ b/core/relay/adaptor/ali/image.go
@@ -25,6 +25,7 @@ import (
 	"github.com/labring/aiproxy/core/relay/meta"
 	"github.com/labring/aiproxy/core/relay/mode"
 	relaymodel "github.com/labring/aiproxy/core/relay/model"
+	"github.com/labring/aiproxy/core/relay/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -805,10 +806,9 @@ func ImageHandler(
 	}
 
 	aliResponse, err := asyncTaskWait(
-		c,
-		meta.Channel.BaseURL,
+		c.Request.Context(),
+		meta,
 		aliTaskResponse.Output.TaskID,
-		meta.Channel.Key,
 	)
 	if err != nil {
 		return adaptor.DoResponseResult{}, relaymodel.WrapperOpenAIError(
@@ -905,10 +905,10 @@ func MultimodalImageHandler(
 	}, nil
 }
 
-func asyncTask(ctx context.Context, baseURL, taskID, key string) (*TaskResponse, error) {
+func asyncTask(ctx context.Context, m *meta.Meta, taskID string) (*TaskResponse, error) {
 	var aliResponse TaskResponse
 
-	taskURL, err := url.JoinPath(baseURL, "/api/v1/tasks", taskID)
+	taskURL, err := url.JoinPath(m.Channel.BaseURL, "/api/v1/tasks", taskID)
 	if err != nil {
 		return &aliResponse, err
 	}
@@ -918,11 +918,9 @@ func asyncTask(ctx context.Context, baseURL, taskID, key string) (*TaskResponse,
 		return &aliResponse, err
 	}
 
-	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Authorization", "Bearer "+m.Channel.Key)
 
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
+	resp, err := utils.DoRequestWithMeta(req, m)
 	if err != nil {
 		return &aliResponse, err
 	}
@@ -938,7 +936,7 @@ func asyncTask(ctx context.Context, baseURL, taskID, key string) (*TaskResponse,
 	return &response, nil
 }
 
-func asyncTaskWait(ctx context.Context, baseURL, taskID, key string) (*TaskResponse, error) {
+func asyncTaskWait(ctx context.Context, m *meta.Meta, taskID string) (*TaskResponse, error) {
 	waitSeconds := 2
 	step := 0
 	maxStep := 20
@@ -946,7 +944,7 @@ func asyncTaskWait(ctx context.Context, baseURL, taskID, key string) (*TaskRespo
 	for {
 		step++
 
-		rsp, err := asyncTask(ctx, baseURL, taskID, key)
+		rsp, err := asyncTask(ctx, m, taskID)
 		if err != nil {
 			return nil, err
 		}

--- a/core/relay/adaptor/aws/utils/client.go
+++ b/core/relay/adaptor/aws/utils/client.go
@@ -47,7 +47,11 @@ func awsClientFromMeta(meta *meta.Meta) (*bedrockruntime.Client, error) {
 		return nil, err
 	}
 
-	httpClient, err := relayutils.LoadHTTPClientE(meta.RequestTimeout, meta.Channel.ProxyURL)
+	httpClient, err := relayutils.LoadHTTPClientWithTLSConfigE(
+		meta.RequestTimeout,
+		meta.Channel.ProxyURL,
+		meta.Channel.SkipTLSVerify,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/core/relay/adaptor/baidu/adaptor.go
+++ b/core/relay/adaptor/baidu/adaptor.go
@@ -1,7 +1,6 @@
 package baidu
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -127,7 +126,12 @@ func (a *Adaptor) SetupRequestHeader(
 ) error {
 	req.Header.Set("Authorization", "Bearer "+meta.Channel.Key)
 
-	accessToken, err := GetAccessToken(context.Background(), meta.Channel.Key)
+	accessToken, err := GetAccessToken(
+		req.Context(),
+		meta.Channel.Key,
+		meta.Channel.ProxyURL,
+		meta.Channel.SkipTLSVerify,
+	)
 	if err != nil {
 		return err
 	}

--- a/core/relay/adaptor/baidu/token.go
+++ b/core/relay/adaptor/baidu/token.go
@@ -22,7 +22,11 @@ type AccessToken struct {
 
 var tokenCache = cache.New(time.Hour*23, time.Minute)
 
-func GetAccessToken(ctx context.Context, apiKey string) (string, error) {
+func GetAccessToken(
+	ctx context.Context,
+	apiKey, proxyURL string,
+	skipTLSVerify bool,
+) (string, error) {
 	if val, ok := tokenCache.Get(apiKey); ok {
 		accessToken, ok := val.(string)
 		if !ok {
@@ -32,7 +36,7 @@ func GetAccessToken(ctx context.Context, apiKey string) (string, error) {
 		return accessToken, nil
 	}
 
-	accessToken, err := getBaiduAccessTokenHelper(ctx, apiKey)
+	accessToken, err := getBaiduAccessTokenHelper(ctx, apiKey, proxyURL, skipTLSVerify)
 	if err != nil {
 		log.Errorf("get baidu access token failed: %v", err)
 		return "", errors.New("get baidu access token failed")
@@ -47,7 +51,11 @@ func GetAccessToken(ctx context.Context, apiKey string) (string, error) {
 	return accessToken.AccessToken, nil
 }
 
-func getBaiduAccessTokenHelper(ctx context.Context, apiKey string) (*AccessToken, error) {
+func getBaiduAccessTokenHelper(
+	ctx context.Context,
+	apiKey, proxyURL string,
+	skipTLSVerify bool,
+) (*AccessToken, error) {
 	clientID, clientSecret, err := getClientIDAndSecret(apiKey)
 	if err != nil {
 		return nil, err
@@ -70,7 +78,12 @@ func getBaiduAccessTokenHelper(ctx context.Context, apiKey string) (*AccessToken
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 
-	res, err := utils.DoRequest(req, 0)
+	client, err := utils.LoadHTTPClientWithTLSConfigE(0, proxyURL, skipTLSVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/core/relay/adaptor/baiduv2/adaptor.go
+++ b/core/relay/adaptor/baiduv2/adaptor.go
@@ -1,7 +1,6 @@
 package baiduv2
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -91,7 +90,12 @@ func (a *Adaptor) SetupRequestHeader(
 	_ *gin.Context,
 	req *http.Request,
 ) error {
-	token, err := GetBearerToken(context.Background(), meta.Channel.Key, meta.Channel.ProxyURL)
+	token, err := GetBearerToken(
+		req.Context(),
+		meta.Channel.Key,
+		meta.Channel.ProxyURL,
+		meta.Channel.SkipTLSVerify,
+	)
 	if err != nil {
 		return err
 	}

--- a/core/relay/adaptor/baiduv2/token.go
+++ b/core/relay/adaptor/baiduv2/token.go
@@ -19,7 +19,11 @@ import (
 
 var tokenCache = cache.New(time.Hour*23, time.Minute)
 
-func GetBearerToken(ctx context.Context, apiKey, proxyURL string) (string, error) {
+func GetBearerToken(
+	ctx context.Context,
+	apiKey, proxyURL string,
+	skipTLSVerify bool,
+) (string, error) {
 	parts := strings.Split(apiKey, "|")
 	if len(parts) != 2 {
 		return "", errors.New("invalid baidu apikey")
@@ -34,7 +38,7 @@ func GetBearerToken(ctx context.Context, apiKey, proxyURL string) (string, error
 		return token, nil
 	}
 
-	tokenResponse, err := getBaiduAccessTokenHelper(ctx, apiKey, proxyURL)
+	tokenResponse, err := getBaiduAccessTokenHelper(ctx, apiKey, proxyURL, skipTLSVerify)
 	if err != nil {
 		log.Errorf("get baiduv2 access token failed: %v", err)
 		return "", errors.New("get baiduv2 access token failed")
@@ -57,6 +61,7 @@ type TokenResponse struct {
 func getBaiduAccessTokenHelper(
 	ctx context.Context,
 	apiKey, proxyURL string,
+	skipTLSVerify bool,
 ) (*TokenResponse, error) {
 	ak, sk, err := getAKAndSK(apiKey)
 	if err != nil {
@@ -80,7 +85,7 @@ func getBaiduAccessTokenHelper(
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Authorization", authorization)
 
-	client, err := relayutils.LoadHTTPClientE(0, proxyURL)
+	client, err := relayutils.LoadHTTPClientWithTLSConfigE(0, proxyURL, skipTLSVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/core/relay/adaptor/deepseek/balance.go
+++ b/core/relay/adaptor/deepseek/balance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/relay/adaptor"
+	"github.com/labring/aiproxy/core/relay/utils"
 )
 
 var _ adaptor.Balancer = (*Adaptor)(nil)
@@ -28,7 +29,12 @@ func (a *Adaptor) GetBalance(channel *model.Channel) (float64, error) {
 
 	req.Header.Set("Authorization", "Bearer "+channel.Key)
 
-	resp, err := http.DefaultClient.Do(req)
+	client, err := utils.LoadHTTPClientWithTLSConfigE(0, channel.ProxyURL, channel.SkipTLSVerify)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/core/relay/adaptor/doc2x/pdf.go
+++ b/core/relay/adaptor/doc2x/pdf.go
@@ -464,7 +464,11 @@ func imageURL2MdBase64(ctx context.Context, m *meta.Meta, url, altText string) (
 	retries := 0
 	maxRetries := 3
 
-	client, err := utils.LoadHTTPClientE(m.RequestTimeout, m.Channel.ProxyURL)
+	client, err := utils.LoadHTTPClientWithTLSConfigE(
+		m.RequestTimeout,
+		m.Channel.ProxyURL,
+		m.Channel.SkipTLSVerify,
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed to create http client: %w", err)
 	}

--- a/core/relay/adaptor/moonshot/balance.go
+++ b/core/relay/adaptor/moonshot/balance.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/relay/adaptor"
+	"github.com/labring/aiproxy/core/relay/utils"
 )
 
 var _ adaptor.Balancer = (*Adaptor)(nil)
@@ -27,7 +28,12 @@ func (a *Adaptor) GetBalance(channel *model.Channel) (float64, error) {
 
 	req.Header.Set("Authorization", "Bearer "+channel.Key)
 
-	resp, err := http.DefaultClient.Do(req)
+	client, err := utils.LoadHTTPClientWithTLSConfigE(0, channel.ProxyURL, channel.SkipTLSVerify)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/core/relay/adaptor/openai/balance.go
+++ b/core/relay/adaptor/openai/balance.go
@@ -8,13 +8,10 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/relay/adaptor"
+	"github.com/labring/aiproxy/core/relay/utils"
 )
 
 var _ adaptor.Balancer = (*Adaptor)(nil)
-
-func (a *Adaptor) GetBalance(channel *model.Channel) (float64, error) {
-	return GetBalance(channel.BaseURL, channel.Key)
-}
 
 type SubscriptionResponse struct {
 	Object             string  `json:"object"`
@@ -32,7 +29,11 @@ type UsageResponse struct {
 }
 
 func GetBalance(baseURL, key string) (float64, error) {
-	u := baseURL
+	return (&Adaptor{}).GetBalance(&model.Channel{BaseURL: baseURL, Key: key})
+}
+
+func (a *Adaptor) GetBalance(channel *model.Channel) (float64, error) {
+	u := channel.BaseURL
 	if u == "" {
 		u = baseURL
 	}
@@ -44,9 +45,14 @@ func GetBalance(baseURL, key string) (float64, error) {
 		return 0, err
 	}
 
-	req1.Header.Set("Authorization", "Bearer "+key)
+	req1.Header.Set("Authorization", "Bearer "+channel.Key)
 
-	res1, err := http.DefaultClient.Do(req1)
+	client, err := utils.LoadHTTPClientWithTLSConfigE(0, channel.ProxyURL, channel.SkipTLSVerify)
+	if err != nil {
+		return 0, err
+	}
+
+	res1, err := client.Do(req1)
 	if err != nil {
 		return 0, err
 	}
@@ -74,9 +80,9 @@ func GetBalance(baseURL, key string) (float64, error) {
 		return 0, err
 	}
 
-	req2.Header.Set("Authorization", "Bearer "+key)
+	req2.Header.Set("Authorization", "Bearer "+channel.Key)
 
-	res2, err := http.DefaultClient.Do(req2)
+	res2, err := client.Do(req2)
 	if err != nil {
 		return 0, err
 	}

--- a/core/relay/adaptor/siliconflow/balance.go
+++ b/core/relay/adaptor/siliconflow/balance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/relay/adaptor"
+	"github.com/labring/aiproxy/core/relay/utils"
 )
 
 var _ adaptor.Balancer = (*Adaptor)(nil)
@@ -28,7 +29,12 @@ func (a *Adaptor) GetBalance(channel *model.Channel) (float64, error) {
 
 	req.Header.Set("Authorization", "Bearer "+channel.Key)
 
-	res, err := http.DefaultClient.Do(req)
+	client, err := utils.LoadHTTPClientWithTLSConfigE(0, channel.ProxyURL, channel.SkipTLSVerify)
+	if err != nil {
+		return 0, err
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/core/relay/adaptor/vertexai/adaptor.go
+++ b/core/relay/adaptor/vertexai/adaptor.go
@@ -430,7 +430,12 @@ func (a *Adaptor) SetupRequestHeader(
 		return nil
 	}
 
-	token, err := getToken(context.Background(), config.ADCJSON)
+	token, err := getToken(
+		req.Context(),
+		config.ADCJSON,
+		meta.Channel.ProxyURL,
+		meta.Channel.SkipTLSVerify,
+	)
 	if err != nil {
 		return err
 	}
@@ -508,7 +513,12 @@ func (a *Adaptor) FetchAsyncUsage(
 	if config.Key != "" {
 		req.Header.Set("X-Goog-Api-Key", config.Key)
 	} else {
-		token, err := getToken(ctx, config.ADCJSON)
+		token, err := getToken(
+			ctx,
+			config.ADCJSON,
+			requestMeta.Channel.ProxyURL,
+			requestMeta.Channel.SkipTLSVerify,
+		)
 		if err != nil {
 			return model.Usage{}, model.UsageContext{}, false, err
 		}

--- a/core/relay/adaptor/vertexai/token.go
+++ b/core/relay/adaptor/vertexai/token.go
@@ -9,7 +9,9 @@ import (
 	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
 	"github.com/bytedance/sonic"
 	"github.com/labring/aiproxy/core/common/conv"
+	"github.com/labring/aiproxy/core/relay/utils"
 	"github.com/patrickmn/go-cache"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
@@ -32,7 +34,7 @@ var tokenCache = cache.New(30*time.Minute, time.Minute)
 
 const defaultScope = "https://www.googleapis.com/auth/cloud-platform"
 
-func getToken(ctx context.Context, adcJSON string) (string, error) {
+func getToken(ctx context.Context, adcJSON, proxyURL string, skipTLSVerify bool) (string, error) {
 	if tokenI, found := tokenCache.Get(adcJSON); found {
 		token, ok := tokenI.(string)
 		if !ok {
@@ -47,6 +49,13 @@ func getToken(ctx context.Context, adcJSON string) (string, error) {
 		return "", fmt.Errorf("failed to decode credentials file: %w", err)
 	}
 
+	httpClient, err := utils.LoadHTTPClientWithTLSConfigE(0, proxyURL, skipTLSVerify)
+	if err != nil {
+		return "", err
+	}
+
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+
 	creds, err := google.CredentialsFromJSONWithParams( //nolint:staticcheck // credentials are from admin-configured service accounts
 		ctx,
 		conv.StringToBytes(adcJSON),
@@ -58,9 +67,9 @@ func getToken(ctx context.Context, adcJSON string) (string, error) {
 		return "", fmt.Errorf("failed to parse credentials: %w", err)
 	}
 
-	c, err := credentials.NewIamCredentialsClient(
+	c, err := credentials.NewIamCredentialsRESTClient(
 		ctx,
-		option.WithCredentials(creds),
+		option.WithHTTPClient(oauth2.NewClient(ctx, creds.TokenSource)),
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to create client: %w", err)

--- a/core/relay/adaptors/channel_proxy_test.go
+++ b/core/relay/adaptors/channel_proxy_test.go
@@ -1,0 +1,257 @@
+package adaptors_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/labring/aiproxy/core/internal/testutil"
+	"github.com/labring/aiproxy/core/model"
+	"github.com/labring/aiproxy/core/relay/adaptor"
+	awsutils "github.com/labring/aiproxy/core/relay/adaptor/aws/utils"
+	"github.com/labring/aiproxy/core/relay/adaptor/baidu"
+	"github.com/labring/aiproxy/core/relay/adaptor/baiduv2"
+	"github.com/labring/aiproxy/core/relay/adaptor/deepseek"
+	"github.com/labring/aiproxy/core/relay/adaptor/doc2x"
+	"github.com/labring/aiproxy/core/relay/adaptor/moonshot"
+	"github.com/labring/aiproxy/core/relay/adaptor/openai"
+	"github.com/labring/aiproxy/core/relay/adaptor/siliconflow"
+	"github.com/labring/aiproxy/core/relay/adaptor/vertexai"
+	"github.com/labring/aiproxy/core/relay/meta"
+	"github.com/labring/aiproxy/core/relay/mode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelBalanceUsesProxy(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name     string
+		balancer adaptor.Balancer
+		paths    map[string]string
+		want     float64
+	}{
+		{
+			name: "openai", balancer: &openai.Adaptor{}, want: 98,
+			paths: map[string]string{
+				"/v1/dashboard/billing/subscription": `{"hard_limit_usd":100,"has_payment_method":true}`,
+				"/v1/dashboard/billing/usage":        `{"total_usage":200}`,
+			},
+		},
+		{
+			name: "deepseek", balancer: &deepseek.Adaptor{}, want: 8.25,
+			paths: map[string]string{
+				"/user/balance": `{"balance_infos":[{"currency":"CNY","total_balance":"8.25"}]}`,
+			},
+		},
+		{
+			name: "moonshot", balancer: &moonshot.Adaptor{}, want: 8.25,
+			paths: map[string]string{
+				"/users/me/balance": `{"data":{"available_balance":8.25}}`,
+			},
+		},
+		{
+			name: "siliconflow", balancer: &siliconflow.Adaptor{}, want: 8.25,
+			paths: map[string]string{
+				"/user/info": `{"data":{"balance":"8.25"}}`,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					body, ok := tt.paths[req.URL.Path]
+					assert.True(t, ok, "unexpected upstream path: %s", req.URL.Path)
+					assert.Equal(t, "Bearer test-key", req.Header.Get("Authorization"))
+
+					_, _ = io.WriteString(w, body)
+				}),
+			)
+			t.Cleanup(upstream.Close)
+			proxy, requests := testutil.NewHTTPProxy(t, upstream, true)
+			balance, err := tt.balancer.GetBalance(&model.Channel{
+				BaseURL: "http://balance.invalid", Key: "test-key",
+				ProxyURL: proxy.URL, SkipTLSVerify: true,
+			})
+			require.NoError(t, err)
+			assert.InDelta(t, tt.want, balance, 0.00001)
+			assert.Len(t, requests, len(tt.paths))
+		})
+	}
+}
+
+func TestChannelTokenRequestsUseProxy(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		adaptor adaptor.Adaptor
+		path    string
+		body    string
+		status  int
+	}{
+		{
+			name: "baidu", adaptor: &baidu.Adaptor{}, path: "/oauth/2.0/token",
+			body: `{"access_token":"test-token","expires_in":3600}`, status: http.StatusOK,
+		},
+		{
+			name: "baiduv2", adaptor: &baiduv2.Adaptor{}, path: "/v1/BCE-BEARER/token",
+			body: `{"token":"test-token","expireTime":"2099-01-01T00:00:00Z"}`, status: http.StatusCreated,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream := httptest.NewTLSServer(
+				http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					assert.Equal(t, tt.path, req.URL.Path)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(tt.status)
+					_, _ = io.WriteString(w, tt.body)
+				}),
+			)
+			t.Cleanup(upstream.Close)
+			proxy, requests := testutil.NewHTTPProxy(t, upstream, false)
+			m := meta.NewMeta(&model.Channel{
+				Key: proxy.URL + "|secret", ProxyURL: proxy.URL, SkipTLSVerify: true,
+			}, mode.ChatCompletions, "test-model", model.ModelConfig{})
+			req, err := http.NewRequestWithContext(
+				t.Context(),
+				http.MethodPost,
+				"https://upstream.invalid/chat",
+				nil,
+			)
+			require.NoError(t, err)
+			require.NoError(t, tt.adaptor.SetupRequestHeader(m, nil, nil, req))
+
+			if tt.name == "baidu" {
+				assert.Equal(t, "test-token", req.URL.Query().Get("access_token"))
+			} else {
+				assert.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+			}
+
+			assert.Len(t, requests, 1)
+		})
+	}
+}
+
+func TestVertexTokenExchangeAndIAMUseProxy(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch req.URL.Path {
+			case "/token":
+				assert.NoError(t, req.ParseForm())
+				assert.Equal(
+					t,
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					req.Form.Get("grant_type"),
+				)
+				assert.NotEmpty(t, req.Form.Get("assertion"))
+
+				_, _ = io.WriteString(
+					w,
+					`{"access_token":"oauth-token","token_type":"Bearer","expires_in":3600}`,
+				)
+			case "/v1/projects/-/serviceAccounts/service@example.invalid:generateAccessToken":
+				assert.Equal(t, "Bearer oauth-token", req.Header.Get("Authorization"))
+
+				_, _ = io.WriteString(
+					w,
+					`{"accessToken":"iam-token","expireTime":"2099-01-01T00:00:00Z"}`,
+				)
+			default:
+				t.Errorf("unexpected token request: %s", req.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}),
+	)
+	t.Cleanup(upstream.Close)
+	proxy, requests := testutil.NewHTTPProxy(t, upstream, false)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	privateKey := pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	//nolint:gosec // Credentials use an ephemeral test key generated above.
+	adc, err := json.Marshal(vertexai.ApplicationDefaultCredentials{
+		Type: "service_account", ProjectID: "test-project",
+		ClientEmail: "service@example.invalid", PrivateKey: string(privateKey),
+		TokenURI: "https://oauth.invalid/token",
+	})
+	require.NoError(t, err)
+
+	m := meta.NewMeta(&model.Channel{
+		Key: "us-central1|" + string(adc), ProxyURL: proxy.URL, SkipTLSVerify: true,
+	}, mode.ChatCompletions, "gemini-test", model.ModelConfig{Type: mode.Gemini})
+	m.RequestTimeout = time.Second
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		"https://upstream.invalid/chat",
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, (&vertexai.Adaptor{}).SetupRequestHeader(m, nil, nil, req))
+	assert.Equal(t, "Bearer iam-token", req.Header.Get("Authorization"))
+	assert.Len(t, requests, 2)
+}
+
+func TestAWSRequestUsesChannelProxyAndTLS(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, "Bearer test-api-key", req.Header.Get("Authorization"))
+			assert.Equal(t, "/model/test-model/invoke", req.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"result":"proxied"}`)
+		}),
+	)
+	t.Cleanup(upstream.Close)
+	proxy, requests := testutil.NewHTTPProxy(t, upstream, false)
+	m := meta.NewMeta(&model.Channel{
+		Key: "us-east-1|test-api-key", ProxyURL: proxy.URL, SkipTLSVerify: true,
+	}, mode.ChatCompletions, "test-model", model.ModelConfig{})
+	client, err := awsutils.AwsClientFromMeta(m)
+	require.NoError(t, err)
+	output, err := client.InvokeModel(t.Context(), &bedrockruntime.InvokeModelInput{
+		ModelId: new("test-model"), ContentType: new("application/json"), Body: []byte(`{}`),
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"result":"proxied"}`, string(output.Body))
+	assert.Len(t, requests, 1)
+}
+
+func TestDoc2xImageUsesChannelProxyAndTLS(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/page.png", req.URL.Path)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = io.WriteString(w, "image-data")
+	}))
+	t.Cleanup(upstream.Close)
+	proxy, requests := testutil.NewHTTPProxy(t, upstream, true)
+	m := meta.NewMeta(&model.Channel{
+		ProxyURL: proxy.URL, SkipTLSVerify: true,
+	}, mode.ChatCompletions, "test-model", model.ModelConfig{})
+	result := doc2x.InlineMdImage(t.Context(), m, "![page](http://image.invalid/page.png)")
+	assert.Equal(t, "![page](data:image/png;base64,aW1hZ2UtZGF0YQ==)", result)
+	assert.Len(t, requests, 1)
+}

--- a/core/relay/utils/http_client.go
+++ b/core/relay/utils/http_client.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -71,6 +72,50 @@ func normalizeProxyURL(proxyURL string) string {
 	return strings.TrimSpace(proxyURL)
 }
 
+func parseProxyURL(proxyURL string) (*url.URL, error) {
+	proxyURL = normalizeProxyURL(proxyURL)
+	if proxyURL == "" {
+		return nil, nil
+	}
+
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, errors.New("invalid proxy URL")
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	switch parsed.Scheme {
+	case "http", "https", "socks5", "socks5h":
+	default:
+		return nil, errors.New("proxy scheme must be http, https, socks5 or socks5h")
+	}
+
+	if parsed.Hostname() == "" {
+		return nil, errors.New("proxy host is required")
+	}
+
+	if port := parsed.Port(); port != "" {
+		value, err := strconv.ParseUint(port, 10, 16)
+		if err != nil || value == 0 {
+			return nil, errors.New("proxy port must be between 1 and 65535")
+		}
+	} else if strings.HasSuffix(parsed.Host, ":") {
+		return nil, errors.New("proxy port is empty")
+	}
+
+	if (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.ForceQuery ||
+		parsed.Fragment != "" {
+		return nil, errors.New("proxy URL cannot contain a path, query or fragment")
+	}
+
+	return parsed, nil
+}
+
+func ValidateProxyURL(proxyURL string) error {
+	_, err := parseProxyURL(proxyURL)
+	return err
+}
+
 func httpClientCacheKey(timeout time.Duration, proxyURL string, skipTLSVerify bool) string {
 	return fmt.Sprintf(
 		"%d|%s|%t",
@@ -94,14 +139,13 @@ func createTransport(
 		}
 	}
 
-	proxyURL = normalizeProxyURL(proxyURL)
-	if proxyURL == "" {
-		return transport, nil
+	parsed, err := parseProxyURL(proxyURL)
+	if err != nil {
+		return nil, err
 	}
 
-	parsed, err := url.Parse(proxyURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid proxy url: %w", err)
+	if parsed == nil {
+		return transport, nil
 	}
 
 	switch strings.ToLower(parsed.Scheme) {
@@ -114,39 +158,29 @@ func createTransport(
 		}
 
 		transport.Proxy = nil
-		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			type dialResult struct {
-				conn net.Conn
-				err  error
-			}
+		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			ctx, cancel := context.WithTimeout(ctx, defaultDialer.Timeout)
+			defer cancel()
 
-			resultCh := make(chan dialResult, 1)
-			go func() {
-				defer close(resultCh)
-
-				conn, err := dialer.Dial(network, addr)
-				resultCh <- dialResult{conn: conn, err: err}
-			}()
-
-			select {
-			case <-ctx.Done():
+			conn, err := dialer.DialContext(ctx, network, address)
+			if err != nil && ctx.Err() != nil {
 				return nil, ctx.Err()
-			case result := <-resultCh:
-				return result.conn, result.err
 			}
+
+			return conn, err
 		}
-	default:
-		return nil, fmt.Errorf("unsupported proxy scheme: %s", parsed.Scheme)
 	}
 
 	return transport, nil
 }
 
-func socks5Dialer(proxyURL *url.URL) (xproxy.Dialer, error) {
-	address := proxyURL.Host
-	if address == "" {
-		return nil, errors.New("invalid proxy url: host is required")
+func socks5Dialer(proxyURL *url.URL) (xproxy.ContextDialer, error) {
+	port := proxyURL.Port()
+	if port == "" {
+		port = "1080"
 	}
+
+	address := net.JoinHostPort(proxyURL.Hostname(), port)
 
 	var auth *xproxy.Auth
 	if proxyURL.User != nil {
@@ -164,7 +198,12 @@ func socks5Dialer(proxyURL *url.URL) (xproxy.Dialer, error) {
 		return nil, fmt.Errorf("create socks5 proxy dialer failed: %w", err)
 	}
 
-	return dialer, nil
+	contextDialer, ok := dialer.(xproxy.ContextDialer)
+	if !ok {
+		return nil, errors.New("SOCKS5 dialer does not support cancellation")
+	}
+
+	return contextDialer, nil
 }
 
 func LoadHTTPClient(timeout time.Duration, proxyURL string) *http.Client {

--- a/core/relay/utils/http_client_test.go
+++ b/core/relay/utils/http_client_test.go
@@ -1,0 +1,394 @@
+package utils_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labring/aiproxy/core/internal/testutil"
+	"github.com/labring/aiproxy/core/model"
+	"github.com/labring/aiproxy/core/relay/meta"
+	"github.com/labring/aiproxy/core/relay/mode"
+	"github.com/labring/aiproxy/core/relay/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelHTTPProxy(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		proxyTLS  bool
+		targetTLS bool
+	}{
+		{name: "HTTP through HTTP"},
+		{name: "HTTPS through HTTP", targetTLS: true},
+		{name: "HTTP through HTTPS", proxyTLS: true},
+		{name: "HTTPS through HTTPS", proxyTLS: true, targetTLS: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, "/v1/models", req.URL.Path)
+				assert.Equal(t, "Bearer upstream-key", req.Header.Get("Authorization"))
+				assert.Empty(t, req.Header.Get("Proxy-Authorization"))
+
+				_, _ = io.WriteString(w, "proxied")
+			})
+
+			var upstream *httptest.Server
+			if tt.targetTLS {
+				upstream = httptest.NewTLSServer(handler)
+			} else {
+				upstream = httptest.NewServer(handler)
+			}
+
+			t.Cleanup(upstream.Close)
+			proxy, requests := testutil.NewHTTPProxy(t, upstream, tt.proxyTLS)
+			proxyURL, err := url.Parse(proxy.URL)
+			require.NoError(t, err)
+
+			proxyURL.User = url.UserPassword("user@example", "p:ass")
+			m := meta.NewMeta(&model.Channel{
+				ProxyURL: proxyURL.String(), SkipTLSVerify: tt.targetTLS || tt.proxyTLS,
+			}, mode.Responses, "test-model", model.ModelConfig{})
+			m.RequestTimeout = time.Second
+			client, err := utils.LoadHTTPClientWithTLSConfigE(
+				m.RequestTimeout, m.Channel.ProxyURL, m.Channel.SkipTLSVerify,
+			)
+			require.NoError(t, err)
+			t.Cleanup(client.CloseIdleConnections)
+
+			scheme := "http"
+			if tt.targetTLS {
+				scheme = "https"
+			}
+
+			req, err := http.NewRequestWithContext(
+				t.Context(), http.MethodGet, scheme+"://upstream.invalid/v1/models", nil,
+			)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer upstream-key")
+			resp, err := utils.DoRequestWithMeta(req, m)
+			require.NoError(t, err)
+
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, "proxied", string(body))
+
+			select {
+			case request := <-requests:
+				wantMethod := http.MethodGet
+				if tt.targetTLS {
+					wantMethod = http.MethodConnect
+				}
+
+				assert.Equal(t, wantMethod, request.Method)
+				assert.Contains(t, request.Host, "upstream.invalid")
+				assert.Equal(
+					t,
+					"Basic "+base64.StdEncoding.EncodeToString([]byte("user@example:p:ass")),
+					request.Authorization,
+				)
+			case <-time.After(time.Second):
+				t.Fatal("proxy did not receive request")
+			}
+		})
+	}
+}
+
+func TestSOCKSProxyCancellationClosesConnection(t *testing.T) {
+	t.Parallel()
+
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	connected := make(chan net.Conn, 1)
+
+	closed := make(chan struct{})
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		connected <- conn
+
+		_, _ = io.Copy(io.Discard, conn)
+
+		close(closed)
+	}()
+
+	client, err := utils.LoadHTTPClientE(time.Second, "socks5://"+listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(client.CloseIdleConnections)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		conn, err := transport.DialContext(ctx, "tcp", "upstream.invalid:80")
+		if conn != nil {
+			_ = conn.Close()
+		}
+
+		result <- err
+	}()
+
+	select {
+	case conn := <-connected:
+		t.Cleanup(func() { _ = conn.Close() })
+	case <-time.After(time.Second):
+		t.Fatal("SOCKS connection did not start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("SOCKS dial did not honor cancellation")
+	}
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("canceled SOCKS handshake leaked its connection")
+	}
+}
+
+func TestSOCKSProxyRequests(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		scheme string
+		auth   bool
+	}{
+		{scheme: "socks5"},
+		{scheme: "socks5", auth: true},
+		{scheme: "socks5h"},
+		{scheme: "socks5h", auth: true},
+	} {
+		t.Run(tt.scheme, func(t *testing.T) {
+			t.Parallel()
+
+			listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = listener.Close() })
+
+			result := make(chan error, 1)
+			go func() {
+				conn, err := listener.Accept()
+				if err != nil {
+					result <- err
+					return
+				}
+				defer conn.Close()
+
+				_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+				result <- serveSOCKSRequest(conn, tt.auth)
+			}()
+
+			proxyURL := &url.URL{Scheme: tt.scheme, Host: listener.Addr().String()}
+			if tt.auth {
+				proxyURL.User = url.UserPassword("user", "password")
+			}
+
+			client, err := utils.LoadHTTPClientE(time.Second, proxyURL.String())
+			require.NoError(t, err)
+			t.Cleanup(client.CloseIdleConnections)
+			req, err := http.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				"http://upstream.invalid/models",
+				nil,
+			)
+			require.NoError(t, err)
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, "socks", string(body))
+			require.NoError(t, <-result)
+		})
+	}
+}
+
+func TestProxyURLValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, proxyURL := range []string{
+		"", "  ", "http://proxy.example", "https://proxy.example:8443/",
+		"socks5://proxy.example", "socks5h://[::1]:1080",
+		" http://user:p%40ss@proxy.example:8080 ",
+	} {
+		t.Run("valid "+proxyURL, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := utils.LoadHTTPClientE(time.Second, proxyURL)
+			require.NoError(t, err)
+			require.NotNil(t, client)
+		})
+	}
+
+	for _, proxyURL := range []string{
+		"localhost:8080", "http://", "https:///proxy", "http://:8080", "socks5://",
+		"ftp://proxy.example", "http://proxy.example:0", "http://proxy.example:65536",
+		"http://proxy.example:", "http://proxy.example/path", "http://proxy.example?token=secret",
+		"http://proxy.example#fragment", "http://user:secret@proxy.example:bad",
+	} {
+		t.Run("invalid "+proxyURL, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := utils.LoadHTTPClientE(time.Second, proxyURL)
+			require.Error(t, err)
+			require.Nil(t, client)
+			assert.NotContains(t, err.Error(), "secret")
+		})
+	}
+}
+
+func serveSOCKSRequest(conn net.Conn, authenticate bool) error {
+	reader := bufio.NewReader(conn)
+
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return err
+	}
+
+	methods := make([]byte, int(header[1]))
+	if _, err := io.ReadFull(reader, methods); err != nil {
+		return err
+	}
+
+	if authenticate {
+		if err := authenticateSOCKSRequest(conn, reader); err != nil {
+			return err
+		}
+	} else if _, err := conn.Write([]byte{5, 0}); err != nil {
+		return err
+	}
+
+	command := make([]byte, 5)
+	if _, err := io.ReadFull(reader, command); err != nil {
+		return err
+	}
+
+	if command[0] != 5 || command[1] != 1 || command[3] != 3 {
+		return &net.AddrError{Err: "expected SOCKS domain CONNECT", Addr: string(command)}
+	}
+
+	address := make([]byte, int(command[4])+2)
+	if _, err := io.ReadFull(reader, address); err != nil {
+		return err
+	}
+
+	if string(address[:len(address)-2]) != "upstream.invalid" {
+		return &net.AddrError{Err: "unexpected SOCKS destination", Addr: string(address)}
+	}
+
+	if _, err := conn.Write([]byte{5, 0, 0, 1, 127, 0, 0, 1, 0, 80}); err != nil {
+		return err
+	}
+
+	req, err := http.ReadRequest(reader)
+	if err != nil {
+		return err
+	}
+	defer req.Body.Close()
+
+	response := &http.Response{
+		StatusCode: http.StatusOK, ProtoMajor: 1, ProtoMinor: 1,
+		Body: io.NopCloser(strings.NewReader("socks")), ContentLength: 5,
+		Header: make(http.Header), Close: true,
+	}
+
+	return response.Write(conn)
+}
+
+func authenticateSOCKSRequest(conn net.Conn, reader *bufio.Reader) error {
+	if _, err := conn.Write([]byte{5, 2}); err != nil {
+		return err
+	}
+
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return err
+	}
+
+	user := make([]byte, int(header[1]))
+	if _, err := io.ReadFull(reader, user); err != nil {
+		return err
+	}
+
+	length, err := reader.ReadByte()
+	if err != nil {
+		return err
+	}
+
+	password := make([]byte, int(length))
+	if _, err := io.ReadFull(reader, password); err != nil {
+		return err
+	}
+
+	if string(user) != "user" || string(password) != "password" {
+		_, err := conn.Write([]byte{1, 1})
+		return err
+	}
+
+	_, err = conn.Write([]byte{1, 0})
+
+	return err
+}
+
+func TestChannelTLSVerificationIsIsolated(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	t.Cleanup(upstream.Close)
+
+	for _, skipTLSVerify := range []bool{true, false, true} {
+		client, err := utils.LoadHTTPClientWithTLSConfigE(time.Second, "", skipTLSVerify)
+		require.NoError(t, err)
+		t.Cleanup(client.CloseIdleConnections)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, upstream.URL, nil)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+
+		if skipTLSVerify {
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		} else {
+			require.ErrorContains(t, err, "x509")
+		}
+	}
+}


### PR DESCRIPTION
配置渠道代理后，部分余额查询、令牌获取和异步图片任务轮询仍使用默认客户端，可能在只能通过代理访问供应商时失败。SOCKS5 握手取消后也可能遗留连接。

- 让 OpenAI、DeepSeek、Moonshot、SiliconFlow 的余额请求，百度令牌请求，以及阿里图片任务轮询使用渠道网络配置。Vertex AI 的 OAuth 和 IAM 请求统一使用带渠道代理的 HTTP 客户端，保留服务账号令牌生成流程。
- AWS 和 Doc2x 的客户端同时传递渠道 TLS 设置；OpenAI 余额查询在未填写基础地址时使用供应商默认地址。
- SOCKS5 使用原生 ContextDialer，取消时关闭连接，并限制握手时间。支持 SOCKS5/SOCKS5h 认证和默认 1080 端口。
- 校验代理协议、主机、端口及地址格式；错误不包含代理凭据。可选更新保留省略/null 不变、空字符串清除的规则，已有异常代理不会阻止无关字段更新。

验证：

- 后端全量 `go test -timeout 60s -count=1 ./...` 通过，`golangci-lint run ./...` 为 0 问题。
- 本地模拟 HTTP/HTTPS 代理、CONNECT 隧道和 SOCKS5 服务，验证代理认证、远端域名传递、请求取消、TLS 配置隔离、余额查询、OAuth/IAM、AWS SDK 和异步任务等路径。
- 代理相关测试通过 `-race`；取消连接和余额代理测试在修复前复现失败，修复后通过。

通用外链素材 URL 转 base64 的下载逻辑仍使用独立的默认客户端。本次覆盖渠道上游 API、鉴权及上述辅助请求，不改变通用素材下载策略。
