### PR TITLE
fix: restore nested price scrolling and show log channels

### DIFF
--- a/core/controller/channel.go
+++ b/core/controller/channel.go
@@ -18,6 +18,7 @@ import (
 	"github.com/labring/aiproxy/core/relay/adaptors"
 	relayutils "github.com/labring/aiproxy/core/relay/utils"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 )
 
 // ChannelTypeMetas godoc
@@ -287,7 +288,13 @@ func GetChannel(c *gin.Context) {
 
 	channel, err := model.GetChannelByID(id)
 	if err != nil {
-		middleware.ErrorResponse(c, http.StatusInternalServerError, err.Error())
+		status := http.StatusInternalServerError
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			status = http.StatusNotFound
+		}
+
+		middleware.ErrorResponse(c, status, err.Error())
+
 		return
 	}
 

--- a/core/controller/channel_test.go
+++ b/core/controller/channel_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,6 +17,46 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetChannelNotFound(t *testing.T) {
+	db, err := model.OpenSQLite(filepath.Join(t.TempDir(), "channels.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.Channel{}, &model.ChannelTest{}))
+
+	previousDB := model.DB
+	model.DB = db
+	t.Cleanup(func() {
+		model.DB = previousDB
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		require.NoError(t, sqlDB.Close())
+	})
+
+	deleted := &model.Channel{Name: "Deleted channel", Type: model.ChannelTypeOpenAI}
+	require.NoError(t, db.Create(deleted).Error)
+	require.NoError(t, db.Delete(deleted).Error)
+
+	for _, id := range []string{strconv.Itoa(deleted.ID), "999999"} {
+		t.Run(id, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Params = gin.Params{{Key: "id", Value: id}}
+			GetChannel(c)
+			require.Equal(t, http.StatusNotFound, recorder.Code)
+			require.Contains(t, recorder.Body.String(), "channel record not found")
+		})
+	}
+
+	t.Run("database failure", func(t *testing.T) {
+		require.NoError(t, db.Migrator().DropTable(&model.Channel{}))
+
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Params = gin.Params{{Key: "id", Value: "1"}}
+		GetChannel(c)
+		require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	})
+}
 
 func TestAddChannelRequestToChannelPreservesNewlinesInKey(t *testing.T) {
 	const key = "first-key\nsecond-key"

--- a/web/src/components/common/ChannelLabel.test.tsx
+++ b/web/src/components/common/ChannelLabel.test.tsx
@@ -62,7 +62,7 @@ describe.each([false, true])('ChannelLabel (compact: %s)', compact => {
 
     it('retains the ID fallback without guessing an unavailable status', async () => {
         await act(async () => root.render(<ChannelLabel id={7} compact={compact} />))
-        expect(container.textContent).toContain('#7')
+        expect(container.textContent).toBe('#7')
         expect(container.querySelector(disabledSelector)).toBeNull()
     })
 })

--- a/web/src/components/common/ChannelLabel.tsx
+++ b/web/src/components/common/ChannelLabel.tsx
@@ -50,7 +50,7 @@ export function ChannelLabel({
                 <span className="truncate max-w-[140px]" title={title}>{name}</span>
                 {info?.status === 2 && <ChannelDisabledBadge compact />}
                 {info?.backup_only && <BackupOnlyBadge compact />}
-                <span className="text-muted-foreground shrink-0 max-w-[80px] truncate" title={`#${id}`}>#{id}</span>
+                {info?.name && <span className="text-muted-foreground shrink-0 max-w-[80px] truncate" title={`#${id}`}>#{id}</span>}
             </span>
         )
     }
@@ -73,7 +73,7 @@ export function ChannelLabel({
             <span className="truncate max-w-[180px]" title={title}>{name}</span>
             {info?.status === 2 && <ChannelDisabledBadge />}
             {info?.backup_only && <BackupOnlyBadge />}
-            <span className="text-muted-foreground shrink-0 max-w-[90px] truncate" title={`(#${id})`}>(#{id})</span>
+            {info?.name && <span className="text-muted-foreground shrink-0 max-w-[90px] truncate" title={`(#${id})`}>(#{id})</span>}
         </span>
     )
 }

--- a/web/src/components/price/PriceDisplay.tsx
+++ b/web/src/components/price/PriceDisplay.tsx
@@ -132,7 +132,8 @@ export function PriceDisplay({ price }: PriceDisplayProps) {
     const hasConditional = price.conditional_prices && price.conditional_prices.length > 0
 
     return (
-        <Popover>
+        // Own the scroll lock so a parent dialog also permits scrolling this portaled panel.
+        <Popover modal>
             <PopoverTrigger asChild>
                 <button type="button" aria-label={t('group.price.title')} className="group grid min-w-40 gap-1 rounded-sm text-left text-xs leading-5 outline-none hover:text-primary focus-visible:ring-2 focus-visible:ring-ring">
                     {summary.length ? summary.map(row => <span key={row.label} className="flex items-baseline justify-between gap-3 whitespace-nowrap"><span className="text-muted-foreground">{row.label}</span><span className="font-mono tabular-nums group-hover:underline">{row.value}</span></span>) : t('group.price.conditionalPrices')}
@@ -143,7 +144,7 @@ export function PriceDisplay({ price }: PriceDisplayProps) {
                     )}
                 </button>
             </PopoverTrigger>
-            <PopoverContent className="max-h-[min(32rem,80dvh)] w-80 max-w-[calc(100vw-2rem)] overflow-y-auto p-4" align="start">
+            <PopoverContent aria-label={t('group.price.title')} className="max-h-[min(32rem,80dvh,var(--radix-popover-content-available-height))] w-80 max-w-[calc(100vw-2rem)] overflow-y-auto overscroll-contain p-4" align="start" collisionPadding={8}>
                 <div className="space-y-2">
                     <h4 className="font-medium text-sm">{t('group.price.title')}</h4>
                     <div className="space-y-1">

--- a/web/src/feature/log/components/ExpandedLogContent.tsx
+++ b/web/src/feature/log/components/ExpandedLogContent.tsx
@@ -7,10 +7,9 @@ import { JsonViewer } from './JsonViewer'
 import { useLogDetail } from '@/feature/log/hooks'
 import type { LogRecord } from '@/types/log'
 import { channelApi } from '@/api/channel'
-import { useChannelInfoMap, useChannelTypeMetas } from '@/feature/channel/hooks'
 import { ChannelLabel } from '@/components/common/ChannelLabel'
 import { ChannelDialog } from '@/feature/channel/components/ChannelDialog'
-import type { Channel } from '@/types/channel'
+import type { Channel, ChannelBasicInfo, ChannelTypeMetaMap } from '@/types/channel'
 import { toast } from 'sonner'
 import { openResourceDialog, showDeletedResourceToast } from '@/utils/resource-dialog'
 import { writeTextToClipboard } from '@/lib/clipboard'
@@ -22,11 +21,14 @@ const formatPrice = (price: number | undefined, unit: number | undefined): strin
     return price.toString()
 }
 
-export const ExpandedLogContent = ({ log }: { log: LogRecord }) => {
+interface ExpandedLogContentProps {
+    log: LogRecord
+    channelInfo?: ChannelBasicInfo
+    typeMetas?: ChannelTypeMetaMap
+}
+
+export const ExpandedLogContent = ({ log, channelInfo, typeMetas }: ExpandedLogContentProps) => {
     const { t } = useTranslation()
-    const { data: typeMetas } = useChannelTypeMetas()
-    const { data: channelInfoMap } = useChannelInfoMap(log.channel ? [log.channel] : [])
-    const channelInfo = channelInfoMap?.[log.channel]
     const [channelDialogOpen, setChannelDialogOpen] = useState(false)
     const [editingChannel, setEditingChannel] = useState<Channel | null>(null)
 

--- a/web/src/feature/log/components/LogTable.test.tsx
+++ b/web/src/feature/log/components/LogTable.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { channelApi } from '@/api/channel'
+import type { LogRecord } from '@/types/log'
+import { LogTable } from './LogTable'
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/api/channel', () => ({
+    channelApi: {
+        getChannelBatchInfo: vi.fn(),
+        getTypeMetas: vi.fn().mockResolvedValue({ 1: { name: 'OpenAI' } }),
+    },
+}))
+
+const reactTestEnvironment = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+reactTestEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+describe('LogTable channel metadata', () => {
+    let container: HTMLDivElement
+    let root: Root
+    let client: QueryClient
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        container = document.createElement('div')
+        document.body.appendChild(container)
+        root = createRoot(container)
+        client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+        vi.mocked(channelApi.getChannelBatchInfo).mockResolvedValue([
+            { id: 7, name: 'Archived channel', type: 1, status: 1, remark: 'Retained metadata' },
+            { id: 8, name: 'Standby channel', type: 1, status: 2, backup_only: true },
+        ])
+    })
+
+    afterEach(async () => {
+        await act(async () => root.unmount())
+        client.clear()
+        container.remove()
+    })
+
+    async function renderLogs(channels: number[]) {
+        const data = channels.map((channel, index) => ({
+            id: index + 1, channel, group: 'test-group', model: 'test-model', code: 200,
+            created_at: '2026-01-01T00:00:02Z', request_at: '2026-01-01T00:00:00Z',
+        } as LogRecord))
+        await act(async () => root.render(
+            <QueryClientProvider client={client}>
+                <LogTable data={data} total={data.length} page={1} pageSize={10}
+                    onPageChange={vi.fn()} onPageSizeChange={vi.fn()} />
+            </QueryClientProvider>,
+        ))
+    }
+
+    it('batches unique channel IDs and reuses metadata in the second column and expanded details', async () => {
+        await renderLogs([8, 7, 8, 9, 0])
+        await act(async () => {
+            await vi.waitFor(() => expect(container.textContent).toContain('Archived channel'))
+        })
+
+        expect(channelApi.getChannelBatchInfo).toHaveBeenCalledExactlyOnceWith([7, 8, 9])
+        expect(container.querySelectorAll('thead th')[1].textContent).toBe('log.channel')
+        const rows = container.querySelectorAll('tbody tr')
+        const standbyCell = rows[0].querySelectorAll('td')[1]
+        expect(standbyCell.textContent).toContain('Standby channel')
+        expect(standbyCell.querySelector('[aria-label="channel.currentlyDisabled"]')).not.toBeNull()
+        expect(standbyCell.querySelector('[aria-label="channel.dialog.backupOnly"]')).not.toBeNull()
+        expect(rows[1].querySelectorAll('td')[1].querySelector('[title="Archived channel · Retained metadata"]')).not.toBeNull()
+        expect(rows[3].querySelectorAll('td')[1].textContent).toContain('#9')
+        expect(rows[4].querySelectorAll('td')[1].textContent).toBe('-')
+
+        await act(async () => (rows[1].querySelector('button') as HTMLButtonElement).click())
+        expect(container.textContent).toContain('Retained metadata')
+        expect(channelApi.getChannelBatchInfo).toHaveBeenCalledTimes(1)
+        expect(container.querySelector('td[colspan="11"]')).not.toBeNull()
+    })
+
+    it('does not fetch channel metadata for rows without a channel', async () => {
+        await renderLogs([0])
+        expect(channelApi.getChannelBatchInfo).not.toHaveBeenCalled()
+        expect(container.querySelectorAll('tbody td')[1].textContent).toBe('-')
+    })
+})

--- a/web/src/feature/log/components/LogTable.tsx
+++ b/web/src/feature/log/components/LogTable.tsx
@@ -15,6 +15,8 @@ import { ExpandedLogContent } from './ExpandedLogContent'
 import { toast } from 'sonner'
 import type { LogRecord } from '@/types/log'
 import { writeTextToClipboard } from '@/lib/clipboard'
+import { ChannelLabel } from '@/components/common/ChannelLabel'
+import { useChannelInfoMap, useChannelTypeMetas } from '@/feature/channel/hooks'
 
 const columnHelper = createColumnHelper<LogRecord>()
 
@@ -45,6 +47,12 @@ export function LogTable({
 }: LogTableProps) {
     const { t } = useTranslation()
     const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
+    const channelIds = useMemo(
+        () => [...new Set(data.map(log => log.channel).filter(id => id > 0))].sort((a, b) => a - b),
+        [data],
+    )
+    const { data: channelInfoMap } = useChannelInfoMap(channelIds)
+    const { data: typeMetas } = useChannelTypeMetas()
 
     const toggleRowExpansion = (rowId: number) => {
         const newExpanded = new Set(expandedRows)
@@ -88,6 +96,24 @@ export function LogTable({
                     </Button>
                 ),
                 size: 40,
+            }),
+            columnHelper.accessor('channel', {
+                header: t('log.channel'),
+                cell: (info) => {
+                    const id = info.getValue()
+                    if (!id) return <span className="text-muted-foreground">-</span>
+                    const channelInfo = channelInfoMap?.[id]
+                    return (
+                        <ChannelLabel
+                            id={id}
+                            info={channelInfo}
+                            typeName={channelInfo ? typeMetas?.[channelInfo.type]?.name : undefined}
+                            compact
+                            className="max-w-full flex-wrap"
+                        />
+                    )
+                },
+                size: 240,
             }),
             columnHelper.accessor('group', {
                 header: t('log.group'),
@@ -225,7 +251,7 @@ export function LogTable({
             }),
         ],
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [t, expandedRows, onOpenGroupLog, copyToClipboard]
+        [t, expandedRows, onOpenGroupLog, copyToClipboard, channelInfoMap, typeMetas]
     )
 
     const table = useReactTable({
@@ -241,7 +267,7 @@ export function LogTable({
             <div className="flex-1 min-h-0">
                 <div className="h-full overflow-hidden border-y bg-card">
                     <div className="overflow-auto h-full">
-                        <table className="w-full min-w-[1000px] table-fixed tabular-nums">
+                        <table className="w-full min-w-[1240px] table-fixed tabular-nums">
                             <thead className="sticky top-0 z-10 bg-muted">
                                 <tr className="border-b border-border">
                                     {table.getHeaderGroups().map((headerGroup) =>
@@ -315,7 +341,11 @@ export function LogTable({
                                             {expandedRows.has(row.original.id) && (
                                                 <tr>
                                                     <td colSpan={columns.length} className="p-0">
-                                                        <ExpandedLogContent log={row.original} />
+                                                        <ExpandedLogContent
+                                                            log={row.original}
+                                                            channelInfo={channelInfoMap?.[row.original.channel]}
+                                                            typeMetas={typeMetas}
+                                                        />
                                                     </td>
                                                 </tr>
                                             )}


### PR DESCRIPTION
Price popovers in a group's model list and model configuration could not scroll because the parent dialog blocked wheel events in the portaled panel. Give the price popover its own modal scroll lock, constrain its height to the available viewport, and keep an 8px edge margin.

Add channel information as the second logs column, including the channel type, name, ID, disabled status and backup-only status. Fetch unique channel IDs once per page and reuse the same metadata in expanded details, preserving names and remarks for deleted channels. Show an unknown channel ID only once, and return HTTP 404 for missing channels so opening deleted channel details displays the existing deleted-resource message.

Validation:
- Native Edge browser testing reproduced the blocked wheel before the fix and verified scrolling to the final conditional price afterward in group models, group model configurations and global models.
- Checked desktop and 390px mobile layouts, popover viewport boundaries, Escape/focus behavior, horizontal log scrolling, and enabled, disabled, backup-only, deleted, unknown and absent channel states.
- Verified the deleted-channel message through the real browser after the backend fix; removed temporary test fixtures afterward.
- All 36 frontend tests passed; TypeScript, Vite production build and lint for changed frontend files passed.
- Controller tests and controller lint passed, including new coverage for deleted/missing channels returning 404 and database failures returning 500.
