### PR TITLE
feat: allow admin to bypass channel model check

### DIFF
--- a/core/common/config/env.go
+++ b/core/common/config/env.go
@@ -8,19 +8,20 @@ import (
 )
 
 var (
-	DebugEnabled         bool
-	DebugSQLEnabled      bool
-	DisableAutoMigrateDB bool
-	AdminKey             string
-	WebPath              string
-	DisableWeb           bool
-	DisableWebRoot       bool
-	FfmpegEnabled        bool
-	InternalToken        string
-	DisableModelConfig   bool
-	Redis                string
-	RedisKeyPrefix       string
-	ConfigFilePath       string
+	DebugEnabled                       bool
+	DebugSQLEnabled                    bool
+	DisableAutoMigrateDB               bool
+	AdminKey                           string
+	WebPath                            string
+	DisableWeb                         bool
+	DisableWebRoot                     bool
+	FfmpegEnabled                      bool
+	InternalToken                      string
+	DisableModelConfig                 bool
+	EnableAdminBypassChannelModelCheck bool
+	Redis                              string
+	RedisKeyPrefix                     string
+	ConfigFilePath                     string
 
 	// OnCall Lark configuration for urgent alerts
 	OnCallLarkAppID     string
@@ -41,6 +42,7 @@ func ReloadEnv() {
 	FfmpegEnabled = env.Bool("FFMPEG_ENABLED", false)
 	InternalToken = os.Getenv("INTERNAL_TOKEN")
 	DisableModelConfig = env.Bool("DISABLE_MODEL_CONFIG", false)
+	EnableAdminBypassChannelModelCheck = env.Bool("ENABLE_ADMIN_BYPASS_CHANNEL_MODEL_CHECK", false)
 	Redis = env.String("REDIS", os.Getenv("REDIS_CONN_STRING"))
 	RedisKeyPrefix = os.Getenv("REDIS_KEY_PREFIX")
 	ConfigFilePath = env.String("CONFIG_FILE_PATH", "./config.yaml")

--- a/core/controller/relay-backup_test.go
+++ b/core/controller/relay-backup_test.go
@@ -426,6 +426,7 @@ func TestInitialGeneralBackupStaysUnlockedAfterPrimaryRecovery(t *testing.T) {
 	}
 	channels := []*model.Channel{primary, backup, otherBackup}
 	mc := &model.ModelCaches{
+		ChannelsByID: map[int]*model.Channel{1: backup},
 		EnabledModel2ChannelsBySet: map[string]map[string][]*model.Channel{
 			model.ChannelDefaultSet: {"backup-test": channels},
 		},
@@ -686,14 +687,16 @@ func TestDesignatedBackupOnlyChannelRemainsPinned(t *testing.T) {
 
 	backup := &model.Channel{
 		ID: 1, Type: model.ChannelTypeOpenAI, Status: model.ChannelStatusEnabled, BackupOnly: true,
+		Models: []string{"backup-test"},
 	}
 	mc := &model.ModelCaches{
+		ChannelsByID: map[int]*model.Channel{1: backup},
 		EnabledModel2ChannelsBySet: map[string]map[string][]*model.Channel{
 			model.ChannelDefaultSet: {"backup-test": {backup}},
 		},
 	}
 	channel, err := GetChannelFromHeader(
-		"1", mc, []string{model.ChannelDefaultSet}, "backup-test", mode.Responses,
+		"1", mc, "backup-test", mode.Responses,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, backup, channel)

--- a/core/controller/relay-channel.go
+++ b/core/controller/relay-channel.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/labring/aiproxy/core/common"
+	"github.com/labring/aiproxy/core/common/config"
 	"github.com/labring/aiproxy/core/middleware"
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/monitor"
@@ -59,10 +60,11 @@ func adaptorSupportsMode(
 }
 
 func GetChannelFromHeader(
+	c *gin.Context,
 	header string,
 	mc *model.ModelCaches,
 	availableSet []string,
-	model string,
+	modelName string,
 	m mode.Mode,
 ) (*model.Channel, error) {
 	channelIDInt, err := strconv.ParseInt(header, 10, 64)
@@ -71,7 +73,7 @@ func GetChannelFromHeader(
 	}
 
 	for _, set := range availableSet {
-		enabledChannels := mc.EnabledModel2ChannelsBySet[set][model]
+		enabledChannels := mc.EnabledModel2ChannelsBySet[set][modelName]
 		if len(enabledChannels) > 0 {
 			for _, channel := range enabledChannels {
 				if int64(channel.ID) == channelIDInt {
@@ -80,7 +82,7 @@ func GetChannelFromHeader(
 						return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
 					}
 
-					if !adaptorSupportsMode(a, mc, channel, model, m) {
+					if !adaptorSupportsMode(a, mc, channel, modelName, m) {
 						return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
 					}
 
@@ -89,7 +91,7 @@ func GetChannelFromHeader(
 			}
 		}
 
-		disabledChannels := mc.DisabledModel2ChannelsBySet[set][model]
+		disabledChannels := mc.DisabledModel2ChannelsBySet[set][modelName]
 		if len(disabledChannels) > 0 {
 			for _, channel := range disabledChannels {
 				if int64(channel.ID) == channelIDInt {
@@ -98,7 +100,7 @@ func GetChannelFromHeader(
 						return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
 					}
 
-					if !adaptorSupportsMode(a, mc, channel, model, m) {
+					if !adaptorSupportsMode(a, mc, channel, modelName, m) {
 						return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
 					}
 
@@ -108,7 +110,41 @@ func GetChannelFromHeader(
 		}
 	}
 
-	return nil, fmt.Errorf("channel %d not found for model `%s`", channelIDInt, model)
+	if canAdminBypassChannelModelCheck(c) {
+		for _, set := range availableSet {
+			for _, channelsByModel := range []map[string][]*model.Channel{
+				mc.EnabledModel2ChannelsBySet[set],
+				mc.DisabledModel2ChannelsBySet[set],
+			} {
+				for _, channels := range channelsByModel {
+					for _, channel := range channels {
+						if int64(channel.ID) != channelIDInt {
+							continue
+						}
+
+						a, ok := adaptors.GetAdaptor(channel.Type)
+						if !ok {
+							return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
+						}
+
+						if !adaptorSupportsMode(a, mc, channel, modelName, m) {
+							return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
+						}
+
+						return channel, nil
+					}
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("channel %d not found for model `%s`", channelIDInt, modelName)
+}
+
+func canAdminBypassChannelModelCheck(c *gin.Context) bool {
+	return config.EnableAdminBypassChannelModelCheck &&
+		config.AdminKey != "" &&
+		middleware.GetToken(c).Key == config.AdminKey
 }
 
 func needPinChannel(m mode.Mode) bool {
@@ -454,6 +490,7 @@ func getInitialChannel(c *gin.Context, modelName string, m mode.Mode) (*initialC
 		}
 
 		channel, err := GetChannelFromHeader(
+			c,
 			channelHeader,
 			middleware.GetModelCaches(c),
 			availableSet,

--- a/core/controller/relay-channel.go
+++ b/core/controller/relay-channel.go
@@ -60,23 +60,40 @@ func adaptorSupportsMode(
 }
 
 func GetChannelFromHeader(
-	c *gin.Context,
 	header string,
 	mc *model.ModelCaches,
 	availableSet []string,
 	modelName string,
 	m mode.Mode,
 ) (*model.Channel, error) {
-	channelIDInt, err := strconv.ParseInt(header, 10, 64)
+	channelIDInt, err := strconv.Atoi(header)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.EnableAdminBypassChannelModelCheck {
+		channel, ok := mc.ChannelsByID[channelIDInt]
+		if !ok {
+			return nil, fmt.Errorf("channel %d not found", channelIDInt)
+		}
+
+		a, ok := adaptors.GetAdaptor(channel.Type)
+		if !ok {
+			return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
+		}
+
+		if !adaptorSupportsMode(a, mc, channel, modelName, m) {
+			return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
+		}
+
+		return channel, nil
 	}
 
 	for _, set := range availableSet {
 		enabledChannels := mc.EnabledModel2ChannelsBySet[set][modelName]
 		if len(enabledChannels) > 0 {
 			for _, channel := range enabledChannels {
-				if int64(channel.ID) == channelIDInt {
+				if channel.ID == channelIDInt {
 					a, ok := adaptors.GetAdaptor(channel.Type)
 					if !ok {
 						return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
@@ -94,7 +111,7 @@ func GetChannelFromHeader(
 		disabledChannels := mc.DisabledModel2ChannelsBySet[set][modelName]
 		if len(disabledChannels) > 0 {
 			for _, channel := range disabledChannels {
-				if int64(channel.ID) == channelIDInt {
+				if channel.ID == channelIDInt {
 					a, ok := adaptors.GetAdaptor(channel.Type)
 					if !ok {
 						return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
@@ -110,41 +127,7 @@ func GetChannelFromHeader(
 		}
 	}
 
-	if canAdminBypassChannelModelCheck(c) {
-		for _, set := range availableSet {
-			for _, channelsByModel := range []map[string][]*model.Channel{
-				mc.EnabledModel2ChannelsBySet[set],
-				mc.DisabledModel2ChannelsBySet[set],
-			} {
-				for _, channels := range channelsByModel {
-					for _, channel := range channels {
-						if int64(channel.ID) != channelIDInt {
-							continue
-						}
-
-						a, ok := adaptors.GetAdaptor(channel.Type)
-						if !ok {
-							return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
-						}
-
-						if !adaptorSupportsMode(a, mc, channel, modelName, m) {
-							return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
-						}
-
-						return channel, nil
-					}
-				}
-			}
-		}
-	}
-
 	return nil, fmt.Errorf("channel %d not found for model `%s`", channelIDInt, modelName)
-}
-
-func canAdminBypassChannelModelCheck(c *gin.Context) bool {
-	return config.EnableAdminBypassChannelModelCheck &&
-		config.AdminKey != "" &&
-		middleware.GetToken(c).Key == config.AdminKey
 }
 
 func needPinChannel(m mode.Mode) bool {
@@ -490,7 +473,6 @@ func getInitialChannel(c *gin.Context, modelName string, m mode.Mode) (*initialC
 		}
 
 		channel, err := GetChannelFromHeader(
-			c,
 			channelHeader,
 			middleware.GetModelCaches(c),
 			availableSet,

--- a/core/controller/relay-channel.go
+++ b/core/controller/relay-channel.go
@@ -75,6 +75,7 @@ func GetChannelFromHeader(
 	if !ok {
 		return nil, fmt.Errorf("channel %d not found", channelIDInt)
 	}
+
 	if !config.EnableAdminBypassChannelModelCheck && !slices.Contains(channel.Models, modelName) {
 		return nil, fmt.Errorf("channel %d not found for model `%s`", channelIDInt, modelName)
 	}

--- a/core/controller/relay-channel.go
+++ b/core/controller/relay-channel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand/v2"
+	"slices"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -62,7 +63,6 @@ func adaptorSupportsMode(
 func GetChannelFromHeader(
 	header string,
 	mc *model.ModelCaches,
-	availableSet []string,
 	modelName string,
 	m mode.Mode,
 ) (*model.Channel, error) {
@@ -71,63 +71,24 @@ func GetChannelFromHeader(
 		return nil, err
 	}
 
-	if config.EnableAdminBypassChannelModelCheck {
-		channel, ok := mc.ChannelsByID[channelIDInt]
-		if !ok {
-			return nil, fmt.Errorf("channel %d not found", channelIDInt)
-		}
-
-		a, ok := adaptors.GetAdaptor(channel.Type)
-		if !ok {
-			return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
-		}
-
-		if !adaptorSupportsMode(a, mc, channel, modelName, m) {
-			return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
-		}
-
-		return channel, nil
+	channel, ok := mc.ChannelsByID[channelIDInt]
+	if !ok {
+		return nil, fmt.Errorf("channel %d not found", channelIDInt)
+	}
+	if !config.EnableAdminBypassChannelModelCheck && !slices.Contains(channel.Models, modelName) {
+		return nil, fmt.Errorf("channel %d not found for model `%s`", channelIDInt, modelName)
 	}
 
-	for _, set := range availableSet {
-		enabledChannels := mc.EnabledModel2ChannelsBySet[set][modelName]
-		if len(enabledChannels) > 0 {
-			for _, channel := range enabledChannels {
-				if channel.ID == channelIDInt {
-					a, ok := adaptors.GetAdaptor(channel.Type)
-					if !ok {
-						return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
-					}
-
-					if !adaptorSupportsMode(a, mc, channel, modelName, m) {
-						return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
-					}
-
-					return channel, nil
-				}
-			}
-		}
-
-		disabledChannels := mc.DisabledModel2ChannelsBySet[set][modelName]
-		if len(disabledChannels) > 0 {
-			for _, channel := range disabledChannels {
-				if channel.ID == channelIDInt {
-					a, ok := adaptors.GetAdaptor(channel.Type)
-					if !ok {
-						return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
-					}
-
-					if !adaptorSupportsMode(a, mc, channel, modelName, m) {
-						return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
-					}
-
-					return channel, nil
-				}
-			}
-		}
+	a, ok := adaptors.GetAdaptor(channel.Type)
+	if !ok {
+		return nil, fmt.Errorf("adaptor not found for channel %d", channel.ID)
 	}
 
-	return nil, fmt.Errorf("channel %d not found for model `%s`", channelIDInt, modelName)
+	if !adaptorSupportsMode(a, mc, channel, modelName, m) {
+		return nil, fmt.Errorf("channel %d not supported by adaptor", channel.ID)
+	}
+
+	return channel, nil
 }
 
 func needPinChannel(m mode.Mode) bool {
@@ -475,7 +436,6 @@ func getInitialChannel(c *gin.Context, modelName string, m mode.Mode) (*initialC
 		channel, err := GetChannelFromHeader(
 			channelHeader,
 			middleware.GetModelCaches(c),
-			availableSet,
 			modelName,
 			m,
 		)

--- a/core/controller/relay-channel_test.go
+++ b/core/controller/relay-channel_test.go
@@ -112,6 +112,9 @@ func TestGetChannelFromHeaderModelCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config.EnableAdminBypassChannelModelCheck = tt.feature
 			channel := &model.Channel{ID: 42, Type: model.ChannelTypeOpenAI, Status: tt.status}
+			if !tt.feature {
+				channel.Models = []string{"configured-model"}
+			}
 
 			mc := &model.ModelCaches{
 				ChannelsByID: map[int]*model.Channel{42: channel},
@@ -140,7 +143,6 @@ func TestGetChannelFromHeaderModelCheck(t *testing.T) {
 			got, err := GetChannelFromHeader(
 				header,
 				mc,
-				[]string{model.ChannelDefaultSet},
 				modelName,
 				m,
 			)

--- a/core/controller/relay-channel_test.go
+++ b/core/controller/relay-channel_test.go
@@ -4,11 +4,13 @@ package controller
 import (
 	"context"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/labring/aiproxy/core/common/config"
 	"github.com/labring/aiproxy/core/middleware"
 	"github.com/labring/aiproxy/core/model"
 	"github.com/labring/aiproxy/core/relay/meta"
@@ -16,6 +18,79 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetInitialChannelAllowsAdminToBypassChannelModelCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	restoreEnv := func(key string) func() {
+		value, exists := os.LookupEnv(key)
+
+		return func() {
+			if exists {
+				require.NoError(t, os.Setenv(key, value))
+			} else {
+				require.NoError(t, os.Unsetenv(key))
+			}
+		}
+	}
+
+	restoreAdminKey := restoreEnv("ADMIN_KEY")
+	restoreFeature := restoreEnv("ENABLE_ADMIN_BYPASS_CHANNEL_MODEL_CHECK")
+	require.NoError(t, os.Setenv("ADMIN_KEY", "admin-key"))
+	t.Cleanup(func() {
+		restoreFeature()
+		restoreAdminKey()
+		config.ReloadEnv()
+	})
+
+	tests := []struct {
+		name       string
+		feature    string
+		tokenKey   string
+		wantBypass bool
+	}{
+		{name: "enabled for admin", feature: "true", tokenKey: "admin-key", wantBypass: true},
+		{name: "disabled feature", feature: "false", tokenKey: "admin-key"},
+		{name: "non-admin token", feature: "true", tokenKey: "regular-key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, os.Setenv("ENABLE_ADMIN_BYPASS_CHANNEL_MODEL_CHECK", tt.feature))
+			config.ReloadEnv()
+
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+			c.Request.Header.Set(AIProxyChannelHeader, "42")
+			c.Set(middleware.Group, model.GroupCache{Status: model.GroupStatusInternal})
+			c.Set(middleware.Token, model.TokenCache{Key: tt.tokenKey})
+			c.Set(middleware.ModelCaches, &model.ModelCaches{
+				EnabledModel2ChannelsBySet: map[string]map[string][]*model.Channel{
+					model.ChannelDefaultSet: {
+						"configured-model": {
+							{
+								ID:     42,
+								Type:   model.ChannelTypeOpenAI,
+								Models: []string{"configured-model"},
+							},
+						},
+					},
+				},
+			})
+
+			initial, err := getInitialChannel(c, "unsaved-model", mode.ChatCompletions)
+			if !tt.wantBypass {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, initial.designatedChannel)
+			assert.Equal(t, 42, initial.channel.ID)
+		})
+	}
+}
 
 func TestGetChannelWithFallbackPreferred(t *testing.T) {
 	t.Parallel()

--- a/core/controller/relay-channel_test.go
+++ b/core/controller/relay-channel_test.go
@@ -111,6 +111,7 @@ func TestGetChannelFromHeaderModelCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config.EnableAdminBypassChannelModelCheck = tt.feature
+
 			channel := &model.Channel{ID: 42, Type: model.ChannelTypeOpenAI, Status: tt.status}
 			if !tt.feature {
 				channel.Models = []string{"configured-model"}

--- a/core/controller/relay-channel_test.go
+++ b/core/controller/relay-channel_test.go
@@ -4,7 +4,6 @@ package controller
 import (
 	"context"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,75 +18,140 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetInitialChannelAllowsAdminToBypassChannelModelCheck(t *testing.T) {
+func TestGetInitialChannelBypassChannelModelCheck(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	restoreEnv := func(key string) func() {
-		value, exists := os.LookupEnv(key)
+	original := config.EnableAdminBypassChannelModelCheck
+	t.Cleanup(func() { config.EnableAdminBypassChannelModelCheck = original })
 
-		return func() {
-			if exists {
-				require.NoError(t, os.Setenv(key, value))
-			} else {
-				require.NoError(t, os.Unsetenv(key))
-			}
-		}
-	}
-
-	restoreAdminKey := restoreEnv("ADMIN_KEY")
-	restoreFeature := restoreEnv("ENABLE_ADMIN_BYPASS_CHANNEL_MODEL_CHECK")
-	require.NoError(t, os.Setenv("ADMIN_KEY", "admin-key"))
-	t.Cleanup(func() {
-		restoreFeature()
-		restoreAdminKey()
-		config.ReloadEnv()
-	})
+	channel := &model.Channel{ID: 42, Type: model.ChannelTypeOpenAI}
 
 	tests := []struct {
-		name       string
-		feature    string
-		tokenKey   string
-		wantBypass bool
+		name      string
+		feature   bool
+		status    int
+		wantError string
 	}{
-		{name: "enabled for admin", feature: "true", tokenKey: "admin-key", wantBypass: true},
-		{name: "disabled feature", feature: "false", tokenKey: "admin-key"},
-		{name: "non-admin token", feature: "true", tokenKey: "regular-key"},
+		{
+			name:    "internal bypasses model and set checks",
+			feature: true,
+			status:  model.GroupStatusInternal,
+		},
+		{name: "feature off", status: model.GroupStatusInternal, wantError: "not found for model"},
+		{
+			name:      "regular group denied",
+			feature:   true,
+			status:    model.GroupStatusEnabled,
+			wantError: "channel header is not allowed",
+		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.NoError(t, os.Setenv("ENABLE_ADMIN_BYPASS_CHANNEL_MODEL_CHECK", tt.feature))
-			config.ReloadEnv()
-
-			recorder := httptest.NewRecorder()
-			c, _ := gin.CreateTestContext(recorder)
-			c.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+			config.EnableAdminBypassChannelModelCheck = tt.feature
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequestWithContext(
+				t.Context(),
+				"POST",
+				"/v1/chat/completions",
+				nil,
+			)
 			c.Request.Header.Set(AIProxyChannelHeader, "42")
-			c.Set(middleware.Group, model.GroupCache{Status: model.GroupStatusInternal})
-			c.Set(middleware.Token, model.TokenCache{Key: tt.tokenKey})
+			c.Set(middleware.Group, model.GroupCache{Status: tt.status})
 			c.Set(middleware.ModelCaches, &model.ModelCaches{
-				EnabledModel2ChannelsBySet: map[string]map[string][]*model.Channel{
-					model.ChannelDefaultSet: {
-						"configured-model": {
-							{
-								ID:     42,
-								Type:   model.ChannelTypeOpenAI,
-								Models: []string{"configured-model"},
-							},
-						},
-					},
-				},
+				ChannelsByID: map[int]*model.Channel{42: channel},
 			})
 
 			initial, err := getInitialChannel(c, "unsaved-model", mode.ChatCompletions)
-			if !tt.wantBypass {
-				require.Error(t, err)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
 				return
 			}
 
 			require.NoError(t, err)
 			require.True(t, initial.designatedChannel)
-			assert.Equal(t, 42, initial.channel.ID)
+			assert.Same(t, channel, initial.channel)
+		})
+	}
+}
+
+func TestGetChannelFromHeaderModelCheck(t *testing.T) {
+	original := config.EnableAdminBypassChannelModelCheck
+	t.Cleanup(func() { config.EnableAdminBypassChannelModelCheck = original })
+
+	tests := []struct {
+		name      string
+		feature   bool
+		status    int
+		header    string
+		modelName string
+		mode      mode.Mode
+		wantError string
+	}{
+		{
+			name:    "enabled channel with no configured models",
+			feature: true,
+			status:  model.ChannelStatusEnabled,
+		},
+		{
+			name:    "disabled channel with no configured models",
+			feature: true,
+			status:  model.ChannelStatusDisabled,
+		},
+		{name: "feature off", wantError: "not found for model"},
+		{name: "configured model without feature", modelName: "configured-model"},
+		{name: "unknown channel", feature: true, header: "43", wantError: "channel 43 not found"},
+		{name: "invalid channel ID", feature: true, header: "invalid", wantError: "invalid syntax"},
+		{
+			name:      "unsupported mode",
+			feature:   true,
+			mode:      mode.Mode(-1),
+			wantError: "not supported by adaptor",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.EnableAdminBypassChannelModelCheck = tt.feature
+			channel := &model.Channel{ID: 42, Type: model.ChannelTypeOpenAI, Status: tt.status}
+
+			mc := &model.ModelCaches{
+				ChannelsByID: map[int]*model.Channel{42: channel},
+			}
+			if !tt.feature {
+				mc.EnabledModel2ChannelsBySet = map[string]map[string][]*model.Channel{
+					model.ChannelDefaultSet: {"configured-model": {channel}},
+				}
+			}
+
+			header := tt.header
+			if header == "" {
+				header = "42"
+			}
+
+			modelName := tt.modelName
+			if modelName == "" {
+				modelName = "unsaved-model"
+			}
+
+			m := tt.mode
+			if m == 0 {
+				m = mode.ChatCompletions
+			}
+
+			got, err := GetChannelFromHeader(
+				header,
+				mc,
+				[]string{model.ChannelDefaultSet},
+				modelName,
+				m,
+			)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Same(t, channel, got)
 		})
 	}
 }

--- a/core/model/model_caches.go
+++ b/core/model/model_caches.go
@@ -22,6 +22,8 @@ type ModelConfigCache interface {
 }
 
 type ModelCaches struct {
+	ChannelsByID map[int]*Channel
+
 	ModelConfig ModelConfigCache
 
 	EnabledModelsBySet       map[string][]string
@@ -70,7 +72,16 @@ func InitModelConfigAndChannelCache() error {
 
 	disabledModel2ChannelsBySet := buildModelToChannelsBySetMap(disabledChannels)
 
+	channelsByID := make(map[int]*Channel, len(enabledChannels)+len(disabledChannels))
+	for _, channels := range [][]*Channel{enabledChannels, disabledChannels} {
+		for _, channel := range channels {
+			channelsByID[channel.ID] = channel
+		}
+	}
+
 	modelCaches.Store(&ModelCaches{
+		ChannelsByID: channelsByID,
+
 		ModelConfig: modelConfig,
 
 		EnabledModelsBySet:       enabledModelsBySet,


### PR DESCRIPTION
## Summary
- add a default-off feature flag for admin-directed channel requests
- allow only ADMIN_KEY requests to select a channel whose model is not yet declared
- preserve existing set and adaptor/mode checks, with regression coverage

## Verification
- go test -timeout 30s -count=1 ./... (from core)
- go vet ./... (from core)

Note: local golangci-lint could not run because it was built with Go 1.25 while this project targets Go 1.26.